### PR TITLE
[#136] Rewrite verify-engine-smoke: functional wiring checks

### DIFF
--- a/scripts/verify-engine-smoke.mjs
+++ b/scripts/verify-engine-smoke.mjs
@@ -1,5 +1,34 @@
 import { existsSync, readFileSync } from "node:fs";
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readFile(path) {
+  if (!existsSync(path)) return null;
+  return readFileSync(path, "utf8");
+}
+
+let failed = false;
+const warnings = [];
+
+function pass(msg) {
+  console.log(`  \u2713 ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`  \u2717 FAIL: ${msg}`);
+  failed = true;
+}
+
+function warn(msg) {
+  warnings.push(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Check 1 — Contract files present
+// ---------------------------------------------------------------------------
+
 const requiredFiles = [
   "lib/orchestration/contracts.ts",
   "lib/orchestration/stateMachine.ts",
@@ -7,21 +36,164 @@ const requiredFiles = [
   "lib/llm/providerContracts.ts",
   "lib/llm/routerContracts.ts",
   "lib/federation/protocol.ts",
-  "lib/federation/registryContracts.ts"
+  "lib/federation/registryContracts.ts",
 ];
 
-const missingFiles = requiredFiles.filter((file) => !existsSync(file));
+const presentFiles = requiredFiles.filter((f) => existsSync(f));
+const missingFiles = requiredFiles.filter((f) => !existsSync(f));
+
+console.log("Engine smoke checks:");
+
 if (missingFiles.length > 0) {
-  console.error(`Engine smoke failed. Missing files: ${missingFiles.join(", ")}`);
-  process.exit(1);
+  fail(
+    `Contract files present (${presentFiles.length}/${requiredFiles.length}) — missing: ${missingFiles.join(", ")}`
+  );
+} else {
+  pass(`Contract files present (${requiredFiles.length}/${requiredFiles.length})`);
 }
 
-const routeContract = readFileSync("lib/auth/routeAccess.ts", "utf8");
+// ---------------------------------------------------------------------------
+// Check 2 — Route contracts defined
+// ---------------------------------------------------------------------------
+
+const routeContractContent = readFile("lib/auth/routeAccess.ts");
 const requiredRoutes = ["/app", "/app/core", "/app/studio"];
-const missingRoutes = requiredRoutes.filter((route) => !routeContract.includes(`path: "${route}"`));
-if (missingRoutes.length > 0) {
-  console.error(`Engine smoke failed. Missing route contracts: ${missingRoutes.join(", ")}`);
-  process.exit(1);
+
+if (routeContractContent === null) {
+  fail("Route contracts defined — lib/auth/routeAccess.ts not found");
+} else {
+  const presentRoutes = requiredRoutes.filter((r) => routeContractContent.includes(`path: "${r}"`));
+  const missingRoutes = requiredRoutes.filter((r) => !routeContractContent.includes(`path: "${r}"`));
+
+  if (missingRoutes.length > 0) {
+    fail(
+      `Route contracts defined (${presentRoutes.length}/${requiredRoutes.length}) — missing: ${missingRoutes.join(", ")}`
+    );
+  } else {
+    pass(`Route contracts defined (${requiredRoutes.length}/${requiredRoutes.length})`);
+  }
 }
 
-console.log("Engine smoke verifier passed.");
+// ---------------------------------------------------------------------------
+// Check 3 — LLM provider registered
+// ---------------------------------------------------------------------------
+// ModelRouter is defined in lib/llm/router.ts; it receives providers via
+// constructor injection. The canonical wiring point is app/api/inference/route.ts
+// which instantiates LocalOllamaProvider and CloudManagedProvider and passes
+// them to ModelRouter. We search there (and fall back to the router itself).
+
+const providerSearchPaths = [
+  "app/api/inference/route.ts",
+  "app/api/ai/health/route.ts",
+  "lib/llm/router.ts",
+  "lib/llm/modelRouter.ts",
+];
+
+let providerFound = null;
+
+for (const p of providerSearchPaths) {
+  const content = readFile(p);
+  if (content === null) continue;
+  if (content.includes("new LocalOllamaProvider")) {
+    providerFound = "LocalOllamaProvider";
+    break;
+  }
+  if (content.includes("new CloudManagedProvider")) {
+    providerFound = "CloudManagedProvider";
+    break;
+  }
+}
+
+if (providerFound) {
+  pass(`LLM provider registered: ${providerFound}`);
+} else {
+  fail(
+    "LLM provider registered — neither new LocalOllamaProvider nor new CloudManagedProvider found in provider search paths"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Check 4 — Queue adapter instantiated
+// ---------------------------------------------------------------------------
+
+const workerRouteContent = readFile("app/api/orchestration/worker-run/route.ts");
+
+if (workerRouteContent === null) {
+  fail("Queue adapter instantiated — app/api/orchestration/worker-run/route.ts not found");
+} else {
+  let adapterFound = null;
+  if (workerRouteContent.includes("new SqsQueueAdapter")) {
+    adapterFound = "SqsQueueAdapter";
+  } else if (workerRouteContent.includes("new InMemoryQueueAdapter")) {
+    adapterFound = "InMemoryQueueAdapter";
+  }
+
+  if (adapterFound) {
+    pass(`Queue adapter instantiated: ${adapterFound}`);
+  } else {
+    fail(
+      "Queue adapter instantiated — neither new SqsQueueAdapter nor new InMemoryQueueAdapter found in worker-run/route.ts"
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 5 — State store imported
+// ---------------------------------------------------------------------------
+
+if (workerRouteContent === null) {
+  fail("State store imported — app/api/orchestration/worker-run/route.ts not found");
+} else {
+  if (workerRouteContent.includes("DynamoOrchestrationStateStore")) {
+    pass("State store imported");
+  } else {
+    fail(
+      "State store imported — DynamoOrchestrationStateStore not found in app/api/orchestration/worker-run/route.ts"
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 6 — Federation API route present and imports from lib/federation/
+// ---------------------------------------------------------------------------
+
+const federationRoutePath = "app/api/federation/route.ts";
+const federationRouteContent = readFile(federationRoutePath);
+
+if (federationRouteContent === null) {
+  fail(`Federation API route present — ${federationRoutePath} does not exist`);
+} else {
+  if (federationRouteContent.includes("from") && federationRouteContent.includes("lib/federation/")) {
+    pass("Federation API route present");
+  } else {
+    fail(
+      `Federation API route present — ${federationRoutePath} exists but does not import from lib/federation/`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 7 — CloudManagedProvider stub detection (WARNING only)
+// ---------------------------------------------------------------------------
+
+const cloudManagedContent = readFile("lib/llm/providers/cloudManaged.ts");
+
+if (cloudManagedContent !== null && cloudManagedContent.includes("Cloud inference request accepted")) {
+  warn("CloudManagedProvider may be fire-and-forget stub (see INF-01)");
+}
+
+// ---------------------------------------------------------------------------
+// Print warnings
+// ---------------------------------------------------------------------------
+
+for (const w of warnings) {
+  console.log(`  \u26a0 WARNING: ${w}`);
+}
+
+// ---------------------------------------------------------------------------
+// Exit
+// ---------------------------------------------------------------------------
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
Fixes #136.

## Summary

- Adds **provider registration check**: scans inference route and router files for `new LocalOllamaProvider` or `new CloudManagedProvider`; fails if neither is found
- Adds **queue adapter instantiation check**: reads `app/api/orchestration/worker-run/route.ts` and verifies `new SqsQueueAdapter` or `new InMemoryQueueAdapter` is present
- Adds **state store import check**: verifies `DynamoOrchestrationStateStore` appears in the worker-run route
- Adds **CloudManagedProvider stub detection**: emits a `WARNING` (non-failing) if `outputText` contains the literal `Cloud inference request accepted` — flags the fire-and-forget EventBridge pattern (INF-01)
- Adds **federation API route check**: verifies `app/api/federation/route.ts` exists AND imports from `lib/federation/`
- Preserves all existing checks (contract file presence, route contract definitions)
- Prints a structured, human-readable summary with pass/fail/warning symbols

## Test plan

- [ ] Run `node scripts/verify-engine-smoke.mjs` locally — all 6 checks pass, CloudManagedProvider warning is emitted
- [ ] Confirm `npm run lint` exits clean
- [ ] Temporarily remove a contract file or provider instantiation and confirm the script exits 1 with a descriptive failure message