### PR TITLE
[#128] Teacher surfaces: live stats, dynamic cohorts, wired review actions

### DIFF
--- a/components/cohorts/CohortList.tsx
+++ b/components/cohorts/CohortList.tsx
@@ -1,18 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
 import CohortCard from "./CohortCard";
 
+type DerivedCohort = {
+  missionId: string;
+  learnerCount: number;
+};
+
 export default function CohortList() {
+  const [cohorts, setCohorts] = useState<DerivedCohort[] | null>(null);
+
+  useEffect(() => {
+    const records = localLedgerAdapter.readAll();
+    const missionRecords = records.filter((r) => r.type === "mission");
+
+    const byMission = new Map<string, Set<string>>();
+    for (const r of missionRecords) {
+      if (!byMission.has(r.missionId)) {
+        byMission.set(r.missionId, new Set());
+      }
+      byMission.get(r.missionId)!.add(r.learnerId);
+    }
+
+    const derived: DerivedCohort[] = Array.from(byMission.entries()).map(
+      ([missionId, learners]) => ({ missionId, learnerCount: learners.size })
+    );
+
+    setCohorts(derived);
+  }, []);
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-semibold" data-tour="page-title">Cohorts</h1>
       <p className="text-sm text-slate-700" data-tour="page-description">
         Manage your learner cohorts, track enrollment, and monitor cohort-level progress.
       </p>
-      <div className="grid gap-3 md:grid-cols-3">
-        <CohortCard name="Demo Cohort A" learnerCount={12} status="active" />
-        <CohortCard name="Demo Cohort B" learnerCount={8} status="pending" />
-        <CohortCard name="Spring Cohort" learnerCount={20} status="completed" />
-      </div>
-      <p className="mt-4 text-xs text-slate-400">Cohort data will populate from your assigned groups. Use Builder to create new cohorts.</p>
+
+      {cohorts === null && (
+        <p className="text-sm text-slate-500">Loading cohort data…</p>
+      )}
+
+      {cohorts !== null && cohorts.length === 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
+          <p className="font-medium text-slate-800">No cohorts assigned yet.</p>
+          <p className="mt-1">Cohorts are created in the Builder.</p>
+          <Link href="/app/builder" className="mt-3 inline-block text-xs text-slate-500 underline">
+            Go to Builder →
+          </Link>
+        </div>
+      )}
+
+      {cohorts !== null && cohorts.length > 0 && (
+        <div className="grid gap-3 md:grid-cols-3">
+          {cohorts.map((c) => (
+            <CohortCard
+              key={c.missionId}
+              name={c.missionId}
+              learnerCount={c.learnerCount}
+              status="active"
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/components/command-center/CommandCenterDashboard.tsx
+++ b/components/command-center/CommandCenterDashboard.tsx
@@ -1,6 +1,34 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
+
+type SummaryStats = {
+  activeCohorts: number;
+  reviewBacklog: number;
+};
 
 export default function CommandCenterDashboard() {
+  const [stats, setStats] = useState<SummaryStats>({ activeCohorts: 0, reviewBacklog: 0 });
+
+  useEffect(() => {
+    const records = localLedgerAdapter.readAll();
+
+    const uniqueMissionIds = new Set(
+      records.filter((r) => r.type === "mission").map((r) => r.missionId)
+    );
+
+    const artifactCount = records.filter(
+      (r) => r.type === "artifact"
+    ).length;
+
+    setStats({
+      activeCohorts: uniqueMissionIds.size,
+      reviewBacklog: artifactCount,
+    });
+  }, []);
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-semibold" data-tour="page-title">Command Center</h1>
@@ -10,18 +38,27 @@ export default function CommandCenterDashboard() {
       <div className="grid gap-3 md:grid-cols-3">
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">Active Cohorts</h2>
-          <p className="mt-1 text-slate-600">View and manage the cohorts you are facilitating.</p>
-          <Link href="/app/cohorts" className="mt-2 inline-block text-xs text-slate-500 underline">Go to Cohorts →</Link>
+          <p className="mt-1 text-3xl font-bold text-slate-800">{stats.activeCohorts}</p>
+          <p className="mt-1 text-slate-500 text-xs">missions tracked in ledger</p>
+          <Link href="/app/cohorts" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Cohorts →
+          </Link>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">Pickup Queue</h2>
-          <p className="mt-1 text-slate-600">Learners awaiting pickup assignments.</p>
-          <Link href="/app/pickups" className="mt-2 inline-block text-xs text-slate-500 underline">Go to Pickups →</Link>
+          <p className="mt-1 text-3xl font-bold text-slate-800">—</p>
+          <p className="mt-1 text-slate-500 text-xs">not yet wired</p>
+          <Link href="/app/pickups" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Pickups →
+          </Link>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">Review Backlog</h2>
-          <p className="mt-1 text-slate-600">Submitted artifacts awaiting your verdict.</p>
-          <Link href="/app/reviews" className="mt-2 inline-block text-xs text-slate-500 underline">Go to Reviews →</Link>
+          <p className="mt-1 text-3xl font-bold text-slate-800">{stats.reviewBacklog}</p>
+          <p className="mt-1 text-slate-500 text-xs">artifact records pending review</p>
+          <Link href="/app/reviews" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Reviews →
+          </Link>
         </article>
       </div>
     </section>

--- a/components/reviews/ReviewCard.tsx
+++ b/components/reviews/ReviewCard.tsx
@@ -1,18 +1,59 @@
 type ReviewCardProps = {
+  id: string;
   artifactTitle: string;
   learnerName: string;
   submittedAt: string;
+  flagged?: boolean;
+  onApprove: (id: string) => void;
+  onReturn: (id: string) => void;
+  onFlag: (id: string) => void;
 };
 
-export default function ReviewCard({ artifactTitle, learnerName, submittedAt }: ReviewCardProps) {
+export default function ReviewCard({
+  id,
+  artifactTitle,
+  learnerName,
+  submittedAt,
+  flagged = false,
+  onApprove,
+  onReturn,
+  onFlag,
+}: ReviewCardProps) {
   return (
     <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-      <h2 className="font-semibold text-slate-900">{artifactTitle}</h2>
-      <p className="mt-1 text-slate-500">By {learnerName} · {submittedAt}</p>
+      <div className="flex items-start justify-between gap-2">
+        <h2 className="font-semibold text-slate-900">{artifactTitle}</h2>
+        {flagged && (
+          <span className="shrink-0 rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+            Flagged
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-slate-500">
+        By {learnerName} · {submittedAt}
+      </p>
       <div className="mt-3 flex gap-2">
-        <button type="button" className="rounded bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700">Approve</button>
-        <button type="button" className="rounded border border-amber-400 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50">Return</button>
-        <button type="button" className="rounded border border-red-300 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50">Flag</button>
+        <button
+          type="button"
+          className="rounded bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700"
+          onClick={() => onApprove(id)}
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          className="rounded border border-amber-400 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50"
+          onClick={() => onReturn(id)}
+        >
+          Return
+        </button>
+        <button
+          type="button"
+          className="rounded border border-red-300 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+          onClick={() => onFlag(id)}
+        >
+          Flag
+        </button>
       </div>
     </article>
   );

--- a/components/reviews/ReviewQueue.tsx
+++ b/components/reviews/ReviewQueue.tsx
@@ -1,30 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
+import type { RuntimeArtifact } from "@/lib/runtime/contracts/types";
 import ReviewCard from "./ReviewCard";
 
+type ReviewItem = {
+  id: string;
+  artifactTitle: string;
+  learnerName: string;
+  submittedAt: string;
+  flagged: boolean;
+};
+
+function formatDate(isoString: string): string {
+  try {
+    return new Date(isoString).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return isoString;
+  }
+}
+
 export default function ReviewQueue() {
+  const [items, setItems] = useState<ReviewItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const records = localLedgerAdapter.readAll();
+    const artifactRecords = records.filter((r) => r.type === "artifact");
+
+    const derived: ReviewItem[] = artifactRecords.map((r) => {
+      const payload = r.payload as RuntimeArtifact;
+      return {
+        id: r.id,
+        artifactTitle: payload.missionId
+          ? `Artifact: Mission ${payload.missionId}`
+          : "Untitled Artifact",
+        learnerName: r.learnerId,
+        submittedAt: formatDate(r.createdAtIso),
+        flagged: false,
+      };
+    });
+
+    setItems(derived);
+    setLoaded(true);
+  }, []);
+
+  function handleApprove(id: string) {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  function handleReturn(id: string) {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  function handleFlag(id: string) {
+    setItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, flagged: true } : item))
+    );
+  }
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-semibold" data-tour="page-title">Review Queue</h1>
       <p className="text-sm text-slate-700">
-        Triage submitted artifacts. Approve, return for revision, or flag submissions needing attention.
+        Triage submitted artifacts. Approve, return for revision, or flag submissions needing
+        attention.
       </p>
-      <div className="grid gap-3 md:grid-cols-2">
-        <ReviewCard
-          artifactTitle="Mission Reflection: Community Impact"
-          learnerName="Alex Rivera"
-          submittedAt="Feb 24, 2026"
-        />
-        <ReviewCard
-          artifactTitle="Artifact: Systems Thinking Analysis"
-          learnerName="Jordan Lee"
-          submittedAt="Feb 23, 2026"
-        />
-        <ReviewCard
-          artifactTitle="Mission Draft: Learning Pathways"
-          learnerName="Sam Patel"
-          submittedAt="Feb 22, 2026"
-        />
-      </div>
-      <p className="mt-4 text-xs text-slate-400">Live submissions will populate from the ledger when enabled.</p>
+
+      {!loaded && <p className="text-sm text-slate-500">Loading review queue…</p>}
+
+      {loaded && items.length === 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
+          <p className="font-medium text-slate-800">No artifacts pending review.</p>
+          <p className="mt-1">
+            Submissions appear here when learners save work in Studio.
+          </p>
+        </div>
+      )}
+
+      {loaded && items.length > 0 && (
+        <div className="grid gap-3 md:grid-cols-2">
+          {items.map((item) => (
+            <ReviewCard
+              key={item.id}
+              id={item.id}
+              artifactTitle={item.artifactTitle}
+              learnerName={item.learnerName}
+              submittedAt={item.submittedAt}
+              flagged={item.flagged}
+              onApprove={handleApprove}
+              onReturn={handleReturn}
+              onFlag={handleFlag}
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #128. Replaces all placeholder/hardcoded demo content across the three teacher-facing surfaces with functional UI shells.

- **CommandCenter:** Converted to `"use client"` component. Reads `localLedgerAdapter.readAll()` on mount and derives live counts: unique mission IDs → Active Cohorts, artifact record count → Review Backlog. Pickup Queue shows `—` until that surface is wired.
- **CohortList:** Removed all hardcoded demo objects ("Demo Cohort A", "Demo Cohort B", "Spring Cohort"). Now groups ledger `mission` records by `missionId`, counts unique learners per mission, and renders `CohortCard` dynamically. Shows an informative empty state with a link to `/app/builder` when no data exists.
- **ReviewQueue / ReviewCard:** Removed all hardcoded demo review items. Reads ledger `artifact` records on mount and maps them to review items. `ReviewCard` now accepts `onApprove`, `onReturn`, `onFlag` handler props. Approve and Return optimistically remove the card from local state; Flag marks the card with a "Flagged" badge without removing it.

## Test plan

- [ ] Visit `/app/command-center` — all three stat cards render with numeric values (0 when ledger is empty, live counts when data exists)
- [ ] Visit `/app/cohorts` — empty state shown when no ledger missions; dynamic cards shown when missions exist
- [ ] Visit `/app/reviews` — empty state shown when no ledger artifacts; cards render with Approve / Return / Flag buttons that update local state correctly
- [ ] `npm run lint` passes with no errors
- [ ] `npm run typecheck` passes with no errors
- [ ] `npm run build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)