### PR TITLE
[#129 #130] Facilitator + Admin surfaces: ledger wiring, Standards Manager, Export downloads

### DIFF
--- a/app/app/standards/page.tsx
+++ b/app/app/standards/page.tsx
@@ -1,4 +1,5 @@
 import ForbiddenPanel from "@/components/app-shell/ForbiddenPanel";
+import StandardsManager from "@/components/standards/StandardsManager";
 import StandardsRegistry from "@/components/standards/StandardsRegistry";
 import { getCurrentAppRole } from "@/lib/auth/currentRole";
 import { isRoleAllowedForPath } from "@/lib/auth/routeAccess";
@@ -12,6 +13,10 @@ export default async function StandardsPage() {
 
   if (!isRoleAllowedForPath("/app/standards", role)) {
     return <ForbiddenPanel message="Standards registry is restricted to administrators." />;
+  }
+
+  if (role === "admin" || role === "super_admin") {
+    return <StandardsManager />;
   }
 
   return <StandardsRegistry />;

--- a/components/builder/BuilderWorkspace.tsx
+++ b/components/builder/BuilderWorkspace.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
+
 function buildEmptyMission() {
   return { title: "", objective: "" };
 }
@@ -21,6 +23,17 @@ export default function BuilderWorkspace() {
       setMissionStatus({ type: "error", message: "Mission title is required." });
       return;
     }
+    const missionId = `mission.${Date.now()}`;
+    const now = new Date().toISOString();
+    localLedgerAdapter.upsert({
+      id: missionId,
+      type: "mission",
+      missionId,
+      learnerId: "builder.teacher",
+      payload: { title: mission.title.trim(), objective: mission.objective.trim() } as never,
+      createdAtIso: now,
+      updatedAtIso: now,
+    });
     setMissionStatus({ type: "success", message: `Mission "${mission.title.trim()}" created. It will appear in your learners' mission lists.` });
     setMission(buildEmptyMission());
   }
@@ -37,6 +50,19 @@ export default function BuilderWorkspace() {
     if (learnerIds.length === 0) {
       setCohortStatus({ type: "error", message: "At least one learner ID is required." });
       return;
+    }
+    const now = new Date().toISOString();
+    for (const learnerId of learnerIds) {
+      const missionId = `mission.${Date.now()}.${learnerId}`;
+      localLedgerAdapter.upsert({
+        id: missionId,
+        type: "mission",
+        missionId,
+        learnerId,
+        payload: { cohortName: cohort.name.trim() } as never,
+        createdAtIso: now,
+        updatedAtIso: now,
+      });
     }
     setCohortStatus({
       type: "success",

--- a/components/exports/ExportReadiness.tsx
+++ b/components/exports/ExportReadiness.tsx
@@ -16,18 +16,55 @@ const KPI_LABELS: Record<PilotMetricKey, string> = {
   admin_export_readiness_rate: "Admin Export Readiness"
 };
 
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export default function ExportReadiness() {
   const summary = useMemo(() => {
     const records = localLedgerAdapter.readAll();
     const runtime = readRuntimeState();
 
     return {
+      records,
       missionCount: Object.keys(runtime.missions).length,
       artifactCount: records.filter((record) => record.type === "artifact").length,
       verificationCount: records.filter((record) => record.type === "verification").length,
       pilotSnapshot: createPilotSnapshotFromLocalState(runtime, records)
     };
   }, []);
+
+  function handleExportJson() {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const data = {
+      exportedAt: new Date().toISOString(),
+      missionCount: summary.missionCount,
+      artifactCount: summary.artifactCount,
+      verificationCount: summary.verificationCount,
+      pilotSnapshot: summary.pilotSnapshot,
+      records: summary.records,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    triggerDownload(blob, `rwfw-snapshot-${timestamp}.json`);
+  }
+
+  function handleExportCsv() {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const header = "id,type,mission_id,learner_id,created_at_iso";
+    const rows = summary.records.map((r) =>
+      [r.id, r.type, r.missionId, r.learnerId, r.createdAtIso]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(",")
+    );
+    const csv = [header, ...rows].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    triggerDownload(blob, `rwfw-ledger-${timestamp}.csv`);
+  }
 
   return (
     <section className="space-y-6">
@@ -43,6 +80,23 @@ export default function ExportReadiness() {
         <div className="grid grid-cols-[220px_1fr] gap-3"><dt className="font-medium text-slate-600">Ledger Artifacts</dt><dd>{summary.artifactCount}</dd></div>
         <div className="grid grid-cols-[220px_1fr] gap-3"><dt className="font-medium text-slate-600">Ledger Verifications</dt><dd>{summary.verificationCount}</dd></div>
       </dl>
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={handleExportJson}
+          className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700"
+        >
+          Export Snapshot
+        </button>
+        <button
+          type="button"
+          onClick={handleExportCsv}
+          className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          Export CSV
+        </button>
+      </div>
 
       <section className="space-y-3" data-tour="admin-pilot-health">
         <h2 className="text-lg font-semibold text-slate-900">Pilot Health</h2>

--- a/components/pickups/PickupsWorkspace.tsx
+++ b/components/pickups/PickupsWorkspace.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
 import { phase1FeatureFlags } from "@/lib/config/featureFlags";
 
 export default function PickupsWorkspace() {
@@ -12,6 +17,38 @@ export default function PickupsWorkspace() {
       </section>
     );
   }
+
+  return <PickupsEnabled />;
+}
+
+function PickupsEnabled() {
+  const queues = useMemo(() => {
+    const records = localLedgerAdapter.readAll();
+    const missions = records.filter((r) => r.type === "mission");
+    const artifacts = records.filter((r) => r.type === "artifact");
+    const verifications = records.filter((r) => r.type === "verification");
+
+    const artifactMissionIds = new Set(artifacts.map((r) => r.missionId));
+    const verificationMissionIds = new Set(verifications.map((r) => r.missionId));
+
+    const pending: string[] = [];
+    const inProgress: string[] = [];
+    const completed: string[] = [];
+
+    for (const mission of missions) {
+      const mid = mission.missionId;
+      if (verificationMissionIds.has(mid)) {
+        completed.push(mid);
+      } else if (artifactMissionIds.has(mid)) {
+        inProgress.push(mid);
+      } else {
+        pending.push(mid);
+      }
+    }
+
+    return { pending, inProgress, completed };
+  }, []);
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-semibold" data-tour="page-title">Pickups</h1>
@@ -19,15 +56,39 @@ export default function PickupsWorkspace() {
       <div className="grid gap-3 md:grid-cols-3">
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">Pending Pickups</h2>
-          <p className="mt-1 text-slate-600">Learners awaiting pickup assignment appear here.</p>
+          <p className="mt-1 text-2xl font-bold text-slate-800">{queues.pending.length}</p>
+          <ul className="mt-2 space-y-1 text-xs text-slate-600">
+            {queues.pending.map((id) => (
+              <li key={id} className="truncate font-mono">{id}</li>
+            ))}
+            {queues.pending.length === 0 && (
+              <li className="text-slate-400">No pending missions.</li>
+            )}
+          </ul>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">In Progress</h2>
-          <p className="mt-1 text-slate-600">Active pickup assignments currently being fulfilled.</p>
+          <p className="mt-1 text-2xl font-bold text-slate-800">{queues.inProgress.length}</p>
+          <ul className="mt-2 space-y-1 text-xs text-slate-600">
+            {queues.inProgress.map((id) => (
+              <li key={id} className="truncate font-mono">{id}</li>
+            ))}
+            {queues.inProgress.length === 0 && (
+              <li className="text-slate-400">No missions in progress.</li>
+            )}
+          </ul>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">Completed</h2>
-          <p className="mt-1 text-slate-600">Completed pickups and fulfillment history.</p>
+          <p className="mt-1 text-2xl font-bold text-slate-800">{queues.completed.length}</p>
+          <ul className="mt-2 space-y-1 text-xs text-slate-600">
+            {queues.completed.map((id) => (
+              <li key={id} className="truncate font-mono">{id}</li>
+            ))}
+            {queues.completed.length === 0 && (
+              <li className="text-slate-400">No completed missions.</li>
+            )}
+          </ul>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- **#129 Builder**: Mission Builder and Cohort Builder now call `localLedgerAdapter.upsert()` on submit, persisting `type: "mission"` records to the local ledger. Mission records use `learnerId: "builder.teacher"`; cohort records loop over each learner ID and write one record per learner.
- **#129 Pickups**: When `enablePickup` flag is active, `PickupsWorkspace` reads all ledger records on mount, classifies missions into Pending (no artifact), In Progress (artifact but no verification), and Completed (has verification), and shows live counts plus a `missionId` list under each card. The amber disabled warning is preserved when the flag is off.
- **#130 Standards**: `app/app/standards/page.tsx` now renders `StandardsManager` (full CRUD) for `admin` and `super_admin` roles, and falls back to read-only `StandardsRegistry` for any other role that passes the route guard.
- **#130 Exports**: `ExportReadiness` adds two download buttons — "Export Snapshot" serializes the full snapshot object to `rwfw-snapshot-{timestamp}.json`, and "Export CSV" converts ledger records to `rwfw-ledger-{timestamp}.csv` (id, type, mission_id, learner_id, created_at_iso columns).

Fixes #129, Fixes #130.

## Test plan

- [ ] Submit Mission Builder form — verify localStorage contains a `type: "mission"` record with `learnerId: "builder.teacher"` and correct title/objective payload
- [ ] Submit Cohort Builder with 3 learner IDs — verify 3 separate `type: "mission"` records appear in localStorage, one per learner
- [ ] Validation: submitting with empty title/no learners still shows error messages without writing to ledger
- [ ] With `NEXT_PUBLIC_ENABLE_PICKUP=true`: Pickups page shows numeric counts and mission ID lists reflecting current ledger state
- [ ] With flag off: Pickups page still shows amber warning banner
- [ ] As `admin` or `super_admin` role: Standards page renders `StandardsManager` (Add/Disable controls visible)
- [ ] As non-admin role (if page is reachable): Standards page renders read-only `StandardsRegistry`
- [ ] Click "Export Snapshot" — browser downloads `rwfw-snapshot-{timestamp}.json` with valid JSON
- [ ] Click "Export CSV" — browser downloads `rwfw-ledger-{timestamp}.csv` with correct column headers and escaped values
- [ ] `npm run lint && npm run typecheck` — clean
- [ ] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)