### PR TITLE
fix(ci): set LEDGER_CONSISTENCY_ALLOW_SKIP in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Release Gate Aggregate
         run: npm run verify:release-gate
+        env:
+          LEDGER_CONSISTENCY_ALLOW_SKIP: "true"
 
       - name: Upload Release Gate Artifact
         if: always()


### PR DESCRIPTION
Release gate now correctly fails when rootwork-ledger.db is absent (VER-01 fix). CI environment has no SQLite DB ledger, so the intentional-skip env var must be set. This is the correct operational posture: skip is explicit and documented, not silent.