### PR TITLE
[Wave2] MissionsList: live runtime data, stage badges, Studio links

### DIFF
--- a/components/missions/MissionsList.tsx
+++ b/components/missions/MissionsList.tsx
@@ -1,25 +1,195 @@
-export default function MissionsList() {
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import type { RuntimeMission, RuntimeMissionStage, VerificationEvent } from "@/lib/runtime/contracts/types";
+import { readRuntimeState } from "@/lib/runtime/engine/store";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type MissionRow = {
+  mission: RuntimeMission;
+  artifactCount: number;
+  verifications: VerificationEvent[];
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STAGE_BADGE: Record<RuntimeMissionStage, { label: string; className: string }> = {
+  not_started: { label: "Not Started", className: "bg-slate-100 text-slate-600" },
+  in_progress: { label: "In Progress", className: "bg-blue-100 text-blue-700" },
+  submitted: { label: "Submitted", className: "bg-amber-100 text-amber-700" },
+  verified: { label: "Verified", className: "bg-green-100 text-green-700" },
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StageBadge({ stage }: { stage: RuntimeMissionStage }) {
+  const { label, className } = STAGE_BADGE[stage] ?? STAGE_BADGE.not_started;
   return (
-    <section className="space-y-4">
-      <h1 className="text-2xl font-semibold" data-tour="page-title">Missions</h1>
-      <p className="text-sm text-slate-700">
-        Track active missions, launch new learning cycles, and submit completed work for review.
-      </p>
-      <div className="grid gap-3 md:grid-cols-3">
-        <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-          <h2 className="font-semibold text-slate-900">Active Missions</h2>
-          <p className="mt-1 text-slate-600">Your in-progress missions appear here. Start a mission to begin tracking progress.</p>
-        </article>
-        <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-          <h2 className="font-semibold text-slate-900">Start a Mission</h2>
-          <p className="mt-1 text-slate-600">Launch a new mission to set your learning intention and begin a structured cycle.</p>
-        </article>
-        <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-          <h2 className="font-semibold text-slate-900">Submit for Review</h2>
-          <p className="mt-1 text-slate-600">When work is complete, submit it to your facilitator for feedback and credit.</p>
-        </article>
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+function MissionCard({ mission, artifactCount, verifications }: MissionRow) {
+  return (
+    <article className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <h2 className="text-base font-semibold text-slate-900 leading-snug">{mission.title}</h2>
+        <StageBadge stage={mission.stage} />
       </div>
-      <p className="mt-4 text-sm text-slate-500">No missions yet. Begin your first learning cycle to get started.</p>
+
+      <dl className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-600">
+        <div className="flex gap-1">
+          <dt className="font-medium text-slate-500">Artifacts:</dt>
+          <dd>{artifactCount} artifact{artifactCount !== 1 ? "s" : ""}</dd>
+        </div>
+        {verifications.length > 0 && (
+          <div className="flex gap-1">
+            <dt className="font-medium text-slate-500">Verifications:</dt>
+            <dd>{verifications.length}</dd>
+          </div>
+        )}
+        <div className="flex gap-1">
+          <dt className="font-medium text-slate-500">Updated:</dt>
+          <dd>{formatDate(mission.updatedAtIso)}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-auto pt-1">
+        <Link
+          href="/app/studio"
+          className="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-slate-700 transition-colors"
+        >
+          Open Studio &rarr;
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-xl border-2 border-dashed border-slate-200 bg-slate-50 px-8 py-14 text-center">
+      {/* Illustrated placeholder */}
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-200 text-3xl" aria-hidden="true">
+        🗺️
+      </div>
+      <div className="space-y-1">
+        <p className="text-lg font-semibold text-slate-800">No missions started yet.</p>
+        <p className="text-sm text-slate-500">
+          Begin a mission from your home page, then return here to track progress.
+        </p>
+      </div>
+      <Link
+        href="/app"
+        className="mt-2 inline-flex items-center gap-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 transition-colors"
+      >
+        Go to Home &rarr;
+      </Link>
+    </div>
+  );
+}
+
+function RuntimeDisabledBanner() {
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-3 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+    >
+      <span aria-hidden="true">⚠️</span>
+      <span>
+        Mission tracking requires{" "}
+        <code className="rounded bg-amber-100 px-1 font-mono text-xs">NEXT_PUBLIC_ENABLE_RUNTIME=true</code>{" "}
+        to be set in your environment.
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function MissionsList() {
+  const runtimeEnabled = Boolean(process.env.NEXT_PUBLIC_ENABLE_RUNTIME);
+
+  // Read runtime state once on mount (localStorage is client-only, so we use
+  // a lazy initialiser inside useState rather than useMemo to avoid SSR issues)
+  const [rows] = useState<MissionRow[]>(() => {
+    const state = readRuntimeState();
+
+    return Object.values(state.missions).map((mission) => ({
+      mission,
+      artifactCount: Object.values(state.artifacts).filter((a) => a.missionId === mission.id).length,
+      verifications: Object.values(state.verifications).filter((v) => v.missionId === mission.id),
+    }));
+  });
+
+  const hasMissions = rows.length > 0;
+
+  return (
+    <section className="space-y-6">
+      {/* Header row */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900" data-tour="page-title">
+            Missions
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Track active missions, launch new learning cycles, and submit completed work for review.
+          </p>
+        </div>
+
+        {hasMissions && (
+          <Link
+            href="/app"
+            className="inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors"
+          >
+            + Start New Mission
+          </Link>
+        )}
+      </div>
+
+      {/* Feature-flag warning (always show the content below regardless) */}
+      {!runtimeEnabled && <RuntimeDisabledBanner />}
+
+      {/* Mission cards or empty state */}
+      {hasMissions ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {rows.map(({ mission, artifactCount, verifications }) => (
+            <MissionCard
+              key={mission.id}
+              mission={mission}
+              artifactCount={artifactCount}
+              verifications={verifications}
+            />
+          ))}
+        </div>
+      ) : (
+        <EmptyState />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the static MissionsList stub with a live runtime-state-driven component
- Reads `readRuntimeState()` on client mount via a lazy `useState` initializer (safe for SSR)
- Renders a card per mission showing: title, color-coded stage badge (not_started/in_progress/submitted/verified), artifact count, verification count, last-updated date, and an "Open Studio" CTA link
- Empty state with illustrated placeholder, "No missions started yet." copy, and a "Go to Home" CTA that routes the learner to PLEHome where missions are created
- "Start New Mission" button appears at the top when at least one mission exists (links back to `/app`)
- Feature-flag guard: shows an amber warning banner when `NEXT_PUBLIC_ENABLE_RUNTIME` is falsy, but still renders the empty state beneath it
- Preserves `data-tour="page-title"` attribute on the heading
- Zero lint errors, zero type errors, build passes

## Test plan

- [ ] With no runtime state in localStorage, confirm empty state card and "Go to Home" link render
- [ ] Start a mission via PLEHome, navigate to /app/missions — confirm mission card appears with correct title and "In Progress" badge
- [ ] Verify artifact count increments after saving an artifact in Studio
- [ ] Verify "submitted" and "verified" badge colors render correctly after advancing stage
- [ ] Unset `NEXT_PUBLIC_ENABLE_RUNTIME` locally and confirm amber banner appears above the empty state
- [ ] Confirm "Open Studio" link routes to `/app/studio`
- [ ] Confirm "Start New Mission" button is absent when no missions exist; present when missions exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)