### PR TITLE
[Wave2] E2E: super_admin role coverage + post-merge CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,54 @@ jobs:
           name: release-gate-report
           path: docs/status/release-gate-latest.json
           if-no-files-found: warn
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: verify
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.E2E_ADMIN_EMAIL != '' }}
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Role E2E
+        run: npm run verify:role-e2e
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+          E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+          E2E_TEACHER_EMAIL: ${{ secrets.E2E_TEACHER_EMAIL }}
+          E2E_TEACHER_PASSWORD: ${{ secrets.E2E_TEACHER_PASSWORD }}
+          E2E_STUDENT_INDEPENDENT_EMAIL: ${{ secrets.E2E_STUDENT_INDEPENDENT_EMAIL }}
+          E2E_STUDENT_INDEPENDENT_PASSWORD: ${{ secrets.E2E_STUDENT_INDEPENDENT_PASSWORD }}
+          E2E_STUDENT_ENROLLED_EMAIL: ${{ secrets.E2E_STUDENT_ENROLLED_EMAIL }}
+          E2E_STUDENT_ENROLLED_PASSWORD: ${{ secrets.E2E_STUDENT_ENROLLED_PASSWORD }}
+          E2E_ADULT_LEARNER_EMAIL: ${{ secrets.E2E_ADULT_LEARNER_EMAIL }}
+          E2E_ADULT_LEARNER_PASSWORD: ${{ secrets.E2E_ADULT_LEARNER_PASSWORD }}
+          E2E_PROFESSIONAL_DEVELOPMENT_EMAIL: ${{ secrets.E2E_PROFESSIONAL_DEVELOPMENT_EMAIL }}
+          E2E_PROFESSIONAL_DEVELOPMENT_PASSWORD: ${{ secrets.E2E_PROFESSIONAL_DEVELOPMENT_PASSWORD }}
+          E2E_SUPER_ADMIN_EMAIL: ${{ secrets.E2E_SUPER_ADMIN_EMAIL }}
+          E2E_SUPER_ADMIN_PASSWORD: ${{ secrets.E2E_SUPER_ADMIN_PASSWORD }}
+
+      - name: Upload E2E Screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: role-e2e-screenshots
+          path: docs/qa/artifacts/role-e2e/**
+          if-no-files-found: warn

--- a/scripts/verify-role-e2e.mjs
+++ b/scripts/verify-role-e2e.mjs
@@ -46,6 +46,13 @@ const roleConfigs = [
     emailEnv: "E2E_ADMIN_EMAIL",
     allowRoutes: ["/app", "/app/evidence", "/app/exports", "/app/standards"],
     denyRoutes: ["/app/studio", "/app/command-center", "/app/cohorts"]
+  },
+  {
+    role: "super_admin",
+    emailEnv: "E2E_SUPER_ADMIN_EMAIL",
+    optional: true,
+    allowRoutes: ["/app", "/app/super-admin", "/app/evidence", "/app/exports", "/app/standards", "/app/settings"],
+    denyRoutes: ["/app/missions", "/app/studio", "/app/command-center", "/app/cohorts", "/app/reviews"]
   }
 ];
 
@@ -154,7 +161,11 @@ async function run() {
   const missing = [];
   for (const config of roleConfigs) {
     if (!process.env[config.emailEnv]) {
-      missing.push(config.emailEnv);
+      if (config.optional) {
+        console.warn(`[SKIP] ${config.role}: ${config.emailEnv} not set — skipping optional role test.`);
+      } else {
+        missing.push(config.emailEnv);
+      }
     }
   }
 
@@ -171,6 +182,9 @@ async function run() {
   try {
     for (const config of roleConfigs) {
       const email = process.env[config.emailEnv];
+      if (!email && config.optional) {
+        continue;
+      }
       const user = await getUserByEmail(email);
       const ticket = await createSignInTicket(user.id);
 
@@ -183,7 +197,7 @@ async function run() {
 
         for (const route of config.allowRoutes) {
           const check = await verifyRoute(page, config.role, route, true, {
-            allowOrgBlocked: (config.role === "teacher" || config.role === "professional_development" || config.role === "admin") && !organizationsEnabled
+            allowOrgBlocked: (config.role === "teacher" || config.role === "professional_development" || config.role === "admin" || config.role === "super_admin") && !organizationsEnabled
           });
           if (check.orgBlocked) {
             outcome.notes.push(`org-blocked:${route}`);


### PR DESCRIPTION
Adds super_admin to verify-role-e2e roleConfigs (skips gracefully if credentials absent). Adds post-merge CI e2e job (depends on verify, runs on push-to-main only, timeout 10m, continue-on-error, uploads screenshots). Adds E2E_SUPER_ADMIN_EMAIL/PASSWORD to .env.example.