### PR TITLE
fix(ci): YAML job condition + env-parity secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_SQS_QUEUE_URL: ${{ secrets.AWS_SQS_QUEUE_URL }}
+          AWS_SQS_DLQ_URL: ${{ secrets.AWS_SQS_DLQ_URL }}
           AWS_DYNAMODB_ORCHESTRATION_TABLE: ${{ secrets.AWS_DYNAMODB_ORCHESTRATION_TABLE }}
           AWS_EVENTBRIDGE_BUS_NAME: ${{ secrets.AWS_EVENTBRIDGE_BUS_NAME }}
+          BEDROCK_MODEL_ID: "amazon.titan-text-express-v1"
 
       - name: Upload Release Gate Artifact
         if: always()
@@ -60,7 +62,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: verify
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.E2E_ADMIN_EMAIL != '' }}
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 10
     continue-on-error: true
     steps:


### PR DESCRIPTION
Two fixes: (1) Job-level `if` cannot reference `secrets` context in GitHub Actions — removed the invalid condition (continue-on-error handles graceful skip). (2) Added AWS_SQS_DLQ_URL and BEDROCK_MODEL_ID to Release Gate env to satisfy verify:env-parity.