### PR TITLE
[#126] AWS credential strategy: runbook, IAM policy, rotation SOP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,12 +27,22 @@ DB_LEDGER_PATH=
 NEXT_PUBLIC_ENABLE_STANDARDS_VERIFIER=false
 
 # Phase 4 hybrid engine env contract
+# AWS_REGION: required for all AWS service calls (e.g., us-east-1)
 AWS_REGION=
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY: static IAM key fallback.
+# Prefer OIDC role assumption in Vercel + GitHub Actions over static keys.
+# Rotate every 90 days — see docs/operations-runbook.md (AWS Credential Strategy).
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+# WARNING: Session tokens are temporary. Never set in Vercel production or long-lived secrets.
+# AWS_SESSION_TOKEN is ONLY valid for local assumed-role sessions; it expires automatically.
+AWS_SESSION_TOKEN=
 AWS_SQS_QUEUE_URL=
 AWS_SQS_DLQ_URL=
 AWS_DYNAMODB_ORCHESTRATION_TABLE=
 AWS_EVENTBRIDGE_BUS_NAME=
 BEDROCK_MODEL_ID=amazon.titan-text-express-v1
+# ALLOW_AWS_WORKER_FALLBACK: set true to fall back to in-memory queue when AWS credentials are unavailable.
 ALLOW_AWS_WORKER_FALLBACK=false
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 OLLAMA_MODEL=llama3.1:8b

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -96,3 +96,52 @@
 - Open `.github/ISSUE_TEMPLATE/INCIDENT_ANNOTATION.md` for every failed deploy incident.
 - Follow `docs/status/INCIDENT_ANNOTATION_WORKFLOW.md` and attach release-gate + deployment evidence.
 - Do not close incident tickets until latest deployment is `Ready` and corrective action is tracked.
+
+## AWS Credential Strategy
+
+### Recommended: IAM Role via OIDC (Vercel + GitHub Actions)
+Prefer OIDC-federated IAM roles over static long-lived access keys wherever possible.
+
+**Vercel production:**
+- Use Vercel's native AWS integration with OIDC to assume an IAM role.
+- Required IAM permissions: `bedrock:InvokeModel`, `sqs:SendMessage`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:Query`, `events:PutEvents`.
+- Configure `AWS_REGION` in Vercel env vars; credentials are auto-injected by the OIDC provider.
+- Do NOT store `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` as static Vercel env vars when OIDC is available.
+
+**GitHub Actions CI:**
+- Use `aws-actions/configure-aws-credentials` with OIDC role assumption (no static keys in secrets).
+- If static keys are required as fallback: rotate every 90 days, alert on expiry via AWS IAM credential report.
+- `AWS_SESSION_TOKEN` is ONLY for temporary/local assumed-role sessions — never set it in Vercel production or long-lived CI secrets.
+
+### Static Key Fallback (Current State — Transition Target)
+The repo currently uses static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` stored in Vercel env vars and GitHub secrets. These are acceptable until OIDC is set up.
+
+**Rotation SOP (every 90 days or on suspected compromise):**
+1. Create new IAM access key for the service account in AWS Console.
+2. Update Vercel env vars: `vercel env add AWS_ACCESS_KEY_ID production` and `AWS_SECRET_ACCESS_KEY`.
+3. Update GitHub secrets: `gh secret set AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+4. Run `npm run verify:env-parity` locally to confirm parity.
+5. Trigger a Vercel redeployment and run `npm run verify:cloud-aws-smoke` against the new deploy.
+6. Deactivate the old IAM key in AWS Console (wait 24h before deleting to allow in-flight requests to complete).
+7. Update `docs/status/aws-credential-rotation-log.md` with rotation date and operator.
+
+**Expiry monitoring:**
+- Set a calendar reminder for the next rotation date.
+- Enable AWS IAM credential report alerts for keys older than 80 days.
+- If `AWS_SESSION_TOKEN` is set and expired: immediately clear it from Vercel and GitHub secrets — session tokens are temporary and must never persist.
+
+### Incident: AWS Credentials Expired or Invalid
+**Symptoms:**
+- `/api/inference` returns `usedFallback: true` with `cloud_inference_failed` message
+- `/api/orchestration/worker-run` returns backend: `{ queue: "in_memory", stateStore: "none" }`
+- `npm run verify:cloud-aws-smoke` fails with AWS auth error
+
+**Immediate mitigation:**
+1. Set `MODEL_ROUTING_POLICY=local_only` in Vercel env vars → disables cloud inference, forces local Ollama fallback.
+2. Set `ALLOW_AWS_WORKER_FALLBACK=true` → worker-run falls back to in-memory queue.
+3. Redeploy. Application remains functional in local-only mode.
+
+**Recovery:**
+1. Rotate credentials per Rotation SOP above.
+2. Remove `MODEL_ROUTING_POLICY=local_only` and `ALLOW_AWS_WORKER_FALLBACK=true` after new credentials verified.
+3. Document incident in `docs/status/aws-credential-rotation-log.md`.

--- a/docs/status/aws-credential-rotation-log.md
+++ b/docs/status/aws-credential-rotation-log.md
@@ -1,0 +1,5 @@
+# AWS Credential Rotation Log
+
+| Date | Operator | Action | Notes |
+|------|----------|--------|-------|
+| 2026-02-27 | Initial setup | Static keys set in Vercel + GitHub secrets | OIDC transition pending |

--- a/infra/aws/credential-strategy.md
+++ b/infra/aws/credential-strategy.md
@@ -1,0 +1,66 @@
+# AWS Credential Strategy — RWFW-LOS
+
+## Overview
+This document defines the credential architecture for AWS services used by RWFW-LOS:
+- **Bedrock** — cloud LLM inference (`CloudManagedProvider`)
+- **SQS** — orchestration job queue (`SqsQueueAdapter`)
+- **DynamoDB** — orchestration state store (`DynamoOrchestrationStateStore`)
+- **EventBridge** — observability/audit event bus
+
+## Required IAM Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BedrockInference",
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel"],
+      "Resource": "arn:aws:bedrock:*::foundation-model/*"
+    },
+    {
+      "Sid": "SQSOrchestration",
+      "Effect": "Allow",
+      "Action": ["sqs:SendMessage", "sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+      "Resource": "<AWS_SQS_QUEUE_URL_ARN>"
+    },
+    {
+      "Sid": "DynamoState",
+      "Effect": "Allow",
+      "Action": ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query", "dynamodb:UpdateItem"],
+      "Resource": "arn:aws:dynamodb:*:*:table/<AWS_DYNAMODB_ORCHESTRATION_TABLE>"
+    },
+    {
+      "Sid": "EventBridgeObservability",
+      "Effect": "Allow",
+      "Action": ["events:PutEvents"],
+      "Resource": "arn:aws:events:*:*:event-bus/<AWS_EVENTBRIDGE_BUS_NAME>"
+    }
+  ]
+}
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AWS_REGION` | Yes | AWS region (e.g., `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | Static fallback | IAM access key ID |
+| `AWS_SECRET_ACCESS_KEY` | Static fallback | IAM secret access key |
+| `AWS_SESSION_TOKEN` | Temporary only | Assumed-role session token — never persist in Vercel/CI |
+| `BEDROCK_MODEL_ID` | Yes | Bedrock model ID (default: `amazon.titan-text-express-v1`) |
+| `AWS_SQS_QUEUE_URL` | Yes | Primary SQS queue URL |
+| `AWS_SQS_DLQ_URL` | Yes | Dead-letter queue URL |
+| `AWS_DYNAMODB_ORCHESTRATION_TABLE` | Yes | DynamoDB table name |
+| `AWS_EVENTBRIDGE_BUS_NAME` | Yes | EventBridge bus name |
+
+## Rotation Schedule
+- Rotate static keys every **90 days**.
+- See `docs/operations-runbook.md` → AWS Credential Strategy → Rotation SOP for step-by-step procedure.
+
+## Fallback Posture
+When AWS credentials are invalid or unavailable:
+- Set `MODEL_ROUTING_POLICY=local_only` → routes inference to local Ollama
+- Set `ALLOW_AWS_WORKER_FALLBACK=true` → worker-run uses in-memory queue
+- Application remains functional; no downtime required for credential rotation


### PR DESCRIPTION
Fixes #126. 

## Changes

- **`docs/operations-runbook.md`** — appended AWS Credential Strategy section covering: OIDC-preferred approach for Vercel + GitHub Actions, static key fallback posture, 90-day rotation SOP (7-step), expiry monitoring guidance, and incident fallback (symptoms, immediate mitigation, recovery).
- **`infra/aws/credential-strategy.md`** — new file documenting the recommended IAM approach: required permissions policy (Bedrock, SQS, DynamoDB, EventBridge), environment variable table with required/optional/temporary distinctions, rotation schedule, and fallback posture.
- **`docs/status/aws-credential-rotation-log.md`** — new rotation log to track future key rotations with date/operator/action/notes columns.
- **`.env.example`** — improved AWS section with inline comments for all keys; added `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` with explicit warning: "Session tokens are temporary. Never set in Vercel production or long-lived secrets."

## Test plan
- [ ] Lint and build pass (`npm run lint && npm run build`)
- [ ] `docs/operations-runbook.md` renders correctly in GitHub — no broken markdown
- [ ] `infra/aws/credential-strategy.md` JSON policy block renders correctly
- [ ] `docs/status/aws-credential-rotation-log.md` table renders correctly
- [ ] `.env.example` AWS section reviewed for comment accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)