### PR TITLE
Close #164: DynamoDB ledger adapter + unified server adapter selection

### DIFF
--- a/app/api/ledger/records/route.ts
+++ b/app/api/ledger/records/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 import { parseAppRole } from "@/lib/auth/userRole";
 import type { LedgerRecord } from "@/lib/ledger/adapter";
-import { createDbLedgerAdapter, getDbLedgerAvailability } from "@/lib/ledger/dbAdapter";
+import { getServerLedgerAdapter } from "@/lib/ledger/server-adapter";
 import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
 
 export const runtime = "nodejs";
@@ -65,9 +65,9 @@ export async function GET(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }
 
-  const availability = getDbLedgerAvailability();
-  if (!availability.enabled) {
-    return withTrace(503, traceId, { error: availability.reason ?? "DB ledger unavailable." });
+  const ledger = getServerLedgerAdapter();
+  if (!ledger.available) {
+    return withTrace(503, traceId, { error: ledger.reason });
   }
 
   const requestedLearnerId = new URL(request.url).searchParams.get("learnerId")?.trim();
@@ -89,13 +89,10 @@ export async function GET(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }
 
-  // availability.enabled=true guarantees databasePath is set per getDbLedgerAvailability().
-  if (!availability.databasePath) {
-    return withTrace(503, traceId, { error: "DB ledger path is unavailable." });
-  }
-  const adapter = createDbLedgerAdapter(availability.databasePath);
-  const allRecords = adapter.readAll();
-  const records = effectiveLearnerId ? allRecords.filter((record) => record.learnerId === effectiveLearnerId) : allRecords;
+  const allRecords = await ledger.adapter.readAll();
+  const records = effectiveLearnerId
+    ? allRecords.filter((record) => record.learnerId === effectiveLearnerId)
+    : allRecords;
 
   return withTrace(200, traceId, {
     records,
@@ -113,9 +110,9 @@ export async function POST(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }
 
-  const availability = getDbLedgerAvailability();
-  if (!availability.enabled) {
-    return withTrace(503, traceId, { error: availability.reason ?? "DB ledger unavailable." });
+  const ledger = getServerLedgerAdapter();
+  if (!ledger.available) {
+    return withTrace(503, traceId, { error: ledger.reason });
   }
 
   let payload: unknown;
@@ -138,9 +135,6 @@ export async function POST(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }
 
-  if (!availability.databasePath) {
-    return withTrace(503, traceId, { error: "DB ledger path is unavailable." });
-  }
-  const stored = createDbLedgerAdapter(availability.databasePath).upsert(payload);
+  const stored = await ledger.adapter.upsert(payload);
   return withTrace(200, traceId, { record: stored });
 }

--- a/lib/ledger/dynamo-adapter.ts
+++ b/lib/ledger/dynamo-adapter.ts
@@ -1,0 +1,79 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+
+import { readAwsCredentials, readAwsRegion } from "@/lib/cloud/awsEnv";
+
+import type { LedgerRecord } from "./adapter";
+
+/**
+ * Async ledger adapter interface for server-side adapters that require async I/O
+ * (e.g. DynamoDB). The SQLite adapter is wrapped to match this interface via
+ * wrapSyncAdapter in lib/ledger/server-adapter.ts.
+ */
+export type AsyncLedgerAdapter = {
+  readAll(): Promise<LedgerRecord[]>;
+  upsert(record: LedgerRecord): Promise<LedgerRecord>;
+  findByMission(missionId: string): Promise<LedgerRecord[]>;
+};
+
+/**
+ * Creates a DynamoDB-backed ledger adapter.
+ *
+ * DynamoDB schema:
+ *   pk  = "ledger#<learnerId>"   (partition key)
+ *   sk  = "<record.id>"          (sort key)
+ *   + all LedgerRecord fields stored as top-level attributes
+ *
+ * The table must have pk (S) as the partition key and sk (S) as the sort key.
+ * Use AWS_DYNAMODB_LEDGER_TABLE or fall back to AWS_DYNAMODB_ORCHESTRATION_TABLE.
+ */
+export function createDynamoLedgerAdapter(tableName: string): AsyncLedgerAdapter {
+  const client = DynamoDBDocumentClient.from(
+    new DynamoDBClient({
+      region: readAwsRegion(),
+      credentials: readAwsCredentials()
+    })
+  );
+
+  return {
+    async readAll(): Promise<LedgerRecord[]> {
+      const result = await client.send(
+        new ScanCommand({
+          TableName: tableName,
+          FilterExpression: "begins_with(pk, :prefix)",
+          ExpressionAttributeValues: { ":prefix": "ledger#" }
+        })
+      );
+
+      return (result.Items ?? []).map(itemToRecord);
+    },
+
+    async upsert(record: LedgerRecord): Promise<LedgerRecord> {
+      await client.send(
+        new PutCommand({
+          TableName: tableName,
+          Item: {
+            pk: `ledger#${record.learnerId}`,
+            sk: record.id,
+            ...record
+          }
+        })
+      );
+
+      return record;
+    },
+
+    async findByMission(missionId: string): Promise<LedgerRecord[]> {
+      const all = await this.readAll();
+      return all.filter((r) => r.missionId === missionId);
+    }
+  };
+}
+
+function itemToRecord(item: Record<string, unknown>): LedgerRecord {
+  // Strip the DynamoDB key fields before casting to LedgerRecord
+  const { pk, sk, ...rest } = item;
+  void pk;
+  void sk;
+  return rest as LedgerRecord;
+}

--- a/lib/ledger/server-adapter.ts
+++ b/lib/ledger/server-adapter.ts
@@ -1,0 +1,76 @@
+import type { AsyncLedgerAdapter } from "./dynamo-adapter";
+import { createDynamoLedgerAdapter } from "./dynamo-adapter";
+import { createDbLedgerAdapter, getDbLedgerAvailability } from "./dbAdapter";
+
+/**
+ * Wraps a synchronous SQLite ledger adapter in the AsyncLedgerAdapter interface
+ * so callers can use a single await-based API regardless of the backend.
+ */
+function wrapSyncAdapter(
+  adapter: ReturnType<typeof createDbLedgerAdapter>
+): AsyncLedgerAdapter {
+  return {
+    readAll: () => Promise.resolve(adapter.readAll()),
+    upsert: (r) => Promise.resolve(adapter.upsert(r)),
+    findByMission: (id) => Promise.resolve(adapter.findByMission(id))
+  };
+}
+
+export type ServerLedgerResult =
+  | { available: false; reason: string }
+  | { available: true; adapter: AsyncLedgerAdapter };
+
+/**
+ * Returns the appropriate server-side ledger adapter based on env configuration:
+ *
+ *   DB_LEDGER_ADAPTER=dynamo   → DynamoDB (Vercel / production)
+ *   NEXT_PUBLIC_ENABLE_DB_LEDGER=true (default) → SQLite via createDbLedgerAdapter
+ *   Otherwise                  → unavailable (use localLedgerAdapter client-side)
+ *
+ * Required env vars for dynamo:
+ *   AWS_DYNAMODB_LEDGER_TABLE (or AWS_DYNAMODB_ORCHESTRATION_TABLE as fallback)
+ *   AWS_REGION
+ */
+export function getServerLedgerAdapter(): ServerLedgerResult {
+  const adapterType = process.env.DB_LEDGER_ADAPTER?.trim();
+
+  if (adapterType === "dynamo") {
+    const table =
+      process.env.AWS_DYNAMODB_LEDGER_TABLE?.trim() ||
+      process.env.AWS_DYNAMODB_ORCHESTRATION_TABLE?.trim();
+    const region = process.env.AWS_REGION?.trim();
+
+    if (!table) {
+      return {
+        available: false,
+        reason:
+          "DB_LEDGER_ADAPTER=dynamo requires AWS_DYNAMODB_LEDGER_TABLE " +
+          "(or AWS_DYNAMODB_ORCHESTRATION_TABLE) to be set."
+      };
+    }
+
+    if (!region) {
+      return {
+        available: false,
+        reason: "DB_LEDGER_ADAPTER=dynamo requires AWS_REGION to be set."
+      };
+    }
+
+    return { available: true, adapter: createDynamoLedgerAdapter(table) };
+  }
+
+  // SQLite path (existing behaviour)
+  const availability = getDbLedgerAvailability();
+  if (!availability.enabled) {
+    return { available: false, reason: availability.reason ?? "DB ledger unavailable." };
+  }
+
+  if (!availability.databasePath) {
+    return { available: false, reason: "DB ledger path is unavailable." };
+  }
+
+  return {
+    available: true,
+    adapter: wrapSyncAdapter(createDbLedgerAdapter(availability.databasePath))
+  };
+}


### PR DESCRIPTION
Closes #164

## Summary

Adds a Vercel-compatible DynamoDB ledger backend alongside the existing SQLite adapter, selected at runtime via `DB_LEDGER_ADAPTER` env var.

### New files
- **`lib/ledger/dynamo-adapter.ts`** — `AsyncLedgerAdapter` interface + DynamoDB implementation (`PutCommand` for upsert, `ScanCommand` for readAll). Schema: `pk = "ledger#<learnerId>"`, `sk = <record.id>`. Reuses `readAwsCredentials`/`readAwsRegion` from `lib/cloud/awsEnv.ts`.
- **`lib/ledger/server-adapter.ts`** — `getServerLedgerAdapter()` selects backend: `DB_LEDGER_ADAPTER=dynamo` → DynamoDB; `NEXT_PUBLIC_ENABLE_DB_LEDGER=true` → SQLite; otherwise unavailable. SQLite adapter wrapped in async shim for a unified API.

### Updated files
- **`app/api/ledger/records/route.ts`** — switched to `getServerLedgerAdapter()`; all adapter calls are now awaited
- **`.env.example`** — documents `DB_LEDGER_ADAPTER` and `AWS_DYNAMODB_LEDGER_TABLE`

## Enabling DynamoDB in production (Vercel)
```
DB_LEDGER_ADAPTER=dynamo
AWS_DYNAMODB_LEDGER_TABLE=<table-name>
AWS_REGION=us-east-1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)