### PR TITLE
Add production health check endpoint and verify script

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,21 +1,133 @@
+import { DynamoDBClient, DescribeTableCommand } from "@aws-sdk/client-dynamodb";
+import { SQSClient, GetQueueAttributesCommand } from "@aws-sdk/client-sqs";
 import { NextResponse } from "next/server";
 
+import { readAwsCredentials, readAwsRegion, readSqsQueueUrl, readDynamoTable } from "@/lib/cloud/awsEnv";
 import { TRACE_HEADER, createTraceId } from "@/lib/observability/trace";
 
-export function GET(): Response {
+export const runtime = "nodejs";
+
+type CheckStatus = "ok" | "error" | "unconfigured";
+
+interface CheckResult {
+  status: CheckStatus;
+  latencyMs?: number;
+  detail?: string;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms)
+  );
+  return Promise.race([promise, timeout]);
+}
+
+async function checkClerk(): Promise<CheckResult> {
+  const secret = process.env.CLERK_SECRET_KEY?.trim();
+  if (!secret) {
+    return { status: "unconfigured", detail: "CLERK_SECRET_KEY not set" };
+  }
+
+  const start = Date.now();
+  try {
+    const res = await withTimeout(
+      fetch("https://api.clerk.com/v1/users?limit=1", {
+        headers: { Authorization: `Bearer ${secret}` }
+      }),
+      3000
+    );
+    const latencyMs = Date.now() - start;
+    if (!res.ok) {
+      return { status: "error", latencyMs, detail: `HTTP ${res.status}` };
+    }
+    return { status: "ok", latencyMs };
+  } catch (err) {
+    return { status: "error", latencyMs: Date.now() - start, detail: String(err) };
+  }
+}
+
+async function checkBedrock(): Promise<CheckResult> {
+  const modelId = process.env.BEDROCK_MODEL_ID?.trim() || process.env.AWS_BEDROCK_MODEL_ID?.trim();
+  const region = readAwsRegion();
+  if (!modelId || !region) {
+    return {
+      status: "unconfigured",
+      detail: `Missing: ${!modelId ? "BEDROCK_MODEL_ID" : ""}${!region ? " AWS_REGION" : ""}`.trim()
+    };
+  }
+  // Config-only check — no API call to avoid cost
+  return { status: "ok", detail: `model=${modelId} region=${region}` };
+}
+
+async function checkSqs(): Promise<CheckResult> {
+  const queueUrl = readSqsQueueUrl();
+  const region = readAwsRegion();
+  if (!queueUrl || !region) {
+    return { status: "unconfigured", detail: "AWS_SQS_QUEUE_URL or AWS_REGION not set" };
+  }
+
+  const client = new SQSClient({ region, credentials: readAwsCredentials() });
+  const start = Date.now();
+  try {
+    const result = await withTimeout(
+      client.send(
+        new GetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          AttributeNames: ["ApproximateNumberOfMessages"]
+        })
+      ),
+      3000
+    );
+    const latencyMs = Date.now() - start;
+    const depth = result.Attributes?.ApproximateNumberOfMessages ?? "unknown";
+    return { status: "ok", latencyMs, detail: `queueDepth=${depth}` };
+  } catch (err) {
+    return { status: "error", latencyMs: Date.now() - start, detail: String(err) };
+  }
+}
+
+async function checkDynamo(): Promise<CheckResult> {
+  const table = readDynamoTable();
+  const region = readAwsRegion();
+  if (!table || !region) {
+    return { status: "unconfigured", detail: "AWS_DYNAMODB_ORCHESTRATION_TABLE or AWS_REGION not set" };
+  }
+
+  const client = new DynamoDBClient({ region, credentials: readAwsCredentials() });
+  const start = Date.now();
+  try {
+    await withTimeout(client.send(new DescribeTableCommand({ TableName: table })), 3000);
+    return { status: "ok", latencyMs: Date.now() - start };
+  } catch (err) {
+    return { status: "error", latencyMs: Date.now() - start, detail: String(err) };
+  }
+}
+
+export async function GET(): Promise<Response> {
   const traceId = createTraceId();
+
+  const [clerk, bedrock, sqs, dynamo] = await Promise.all([
+    checkClerk(),
+    checkBedrock(),
+    checkSqs(),
+    checkDynamo()
+  ]);
+
+  const checks = { clerk, bedrock, sqs, dynamo };
+
+  const hasError = Object.values(checks).some((c) => c.status === "error");
+  const overallStatus = hasError ? "degraded" : "ok";
 
   return NextResponse.json(
     {
-      status: "ok",
+      status: overallStatus,
       service: "rwfw-los",
-      timestampIso: new Date().toISOString()
+      timestampIso: new Date().toISOString(),
+      checks
     },
     {
-      status: 200,
-      headers: {
-        [TRACE_HEADER]: traceId
-      }
+      status: hasError ? 503 : 200,
+      headers: { [TRACE_HEADER]: traceId }
     }
   );
 }

--- a/scripts/verify-health-check.mjs
+++ b/scripts/verify-health-check.mjs
@@ -1,0 +1,91 @@
+/**
+ * verify:health-check
+ *
+ * Hits /api/health on the configured base URL and validates the response shape.
+ * Passes as long as the endpoint returns a parseable JSON body with `status` and
+ * `checks`; individual service checks may be "unconfigured" or "error" without
+ * blocking this gate (those are environment concerns, not code concerns).
+ *
+ * Set ROOTWORK_SYNTHETIC_BASE_URL (or falls back to http://localhost:3000).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { config as loadEnv } from "dotenv";
+
+loadEnv({ path: ".env.local" });
+loadEnv();
+
+const baseUrl = (process.env.ROOTWORK_SYNTHETIC_BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+const url = `${baseUrl}/api/health`;
+
+const reportDir = resolve("docs", "status");
+const reportPath = resolve(reportDir, "health-check-latest.json");
+
+async function run() {
+  console.log(`[health-check] GET ${url}`);
+
+  let body;
+  let statusCode;
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    statusCode = res.status;
+    const text = await res.text();
+    body = JSON.parse(text);
+  } catch (err) {
+    const report = {
+      generatedAtIso: new Date().toISOString(),
+      url,
+      passed: false,
+      error: String(err)
+    };
+    mkdirSync(reportDir, { recursive: true });
+    writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    console.error(`[health-check] Request failed: ${err.message || err}`);
+    process.exit(1);
+  }
+
+  const passed =
+    typeof body === "object" &&
+    body !== null &&
+    typeof body.status === "string" &&
+    typeof body.checks === "object";
+
+  const report = {
+    generatedAtIso: new Date().toISOString(),
+    url,
+    statusCode,
+    overallStatus: body?.status,
+    checks: body?.checks,
+    passed
+  };
+
+  mkdirSync(reportDir, { recursive: true });
+  writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+  if (!passed) {
+    console.error(`[health-check] Unexpected response shape (HTTP ${statusCode}):`, body);
+    process.exit(1);
+  }
+
+  const checks = body.checks ?? {};
+  for (const [name, result] of Object.entries(checks)) {
+    const status = result?.status ?? "unknown";
+    const detail = result?.detail ? ` — ${result.detail}` : "";
+    const latency = result?.latencyMs != null ? ` (${result.latencyMs}ms)` : "";
+    if (status === "error") {
+      console.warn(`[health-check] [WARN] ${name}: ${status}${latency}${detail}`);
+    } else {
+      console.log(`[health-check] ${name}: ${status}${latency}${detail}`);
+    }
+  }
+
+  console.log(`[health-check] Overall: ${body.status} (HTTP ${statusCode})`);
+  console.log(`[health-check] Report written to ${reportPath}`);
+}
+
+run().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Extends `/api/health` with parallel checks for Clerk, Bedrock config, SQS, and DynamoDB (3-second timeouts each)
- Returns `status: "ok" | "degraded"` with per-service `latencyMs` and `detail`
- Adds `scripts/verify-health-check.mjs` to hit the endpoint and validate response shape during release gate (non-blocking)

## Test plan
- [ ] `GET /api/health` returns `{ status, service, timestampIso, checks }` with 200 when all services unconfigured or healthy
- [ ] Returns HTTP 503 + `status: "degraded"` if any check errors
- [ ] `npm run verify:health-check` passes against a running dev server
- [ ] Lint + typecheck pass

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)