### PR TITLE
Add server-side backend persistence for runtime, licensing, and standards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,12 @@ AWS_DYNAMODB_ORCHESTRATION_TABLE=
 # Dedicated DynamoDB table for the ledger adapter (DB_LEDGER_ADAPTER=dynamo).
 # Falls back to AWS_DYNAMODB_ORCHESTRATION_TABLE with a "ledger#" key prefix if unset.
 AWS_DYNAMODB_LEDGER_TABLE=
+# Dedicated DynamoDB table for runtime state persistence (pk: runtime#<learnerId>, sk: state).
+AWS_DYNAMODB_RUNTIME_TABLE=
+# Dedicated DynamoDB table for licensing tenants and teacher assignments.
+AWS_DYNAMODB_LICENSING_TABLE=
+# Dedicated DynamoDB table for standards config (pk: standards, sk: config).
+AWS_DYNAMODB_STANDARDS_TABLE=
 AWS_EVENTBRIDGE_BUS_NAME=
 BEDROCK_MODEL_ID=amazon.titan-text-express-v1
 # ALLOW_AWS_WORKER_FALLBACK: set true to fall back to in-memory queue when AWS credentials are unavailable.

--- a/app/api/licensing/assignments/route.ts
+++ b/app/api/licensing/assignments/route.ts
@@ -1,0 +1,99 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import { parseAppRole } from "@/lib/auth/userRole";
+import { getLicensingAdapter } from "@/lib/licensing/dynamoAdapter";
+import type { TeacherAssignmentRecord } from "@/lib/licensing/types";
+import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
+
+export const runtime = "nodejs";
+
+const ALLOWED_ROLES = new Set(["admin", "super_admin"]);
+
+function withTrace(status: number, traceId: string, body: unknown): Response {
+  return NextResponse.json(body, { status, headers: { [TRACE_HEADER]: traceId } });
+}
+
+function isAssignment(value: unknown): value is TeacherAssignmentRecord {
+  if (!value || typeof value !== "object") return false;
+  const a = value as Partial<TeacherAssignmentRecord>;
+  return (
+    typeof a.id === "string" &&
+    typeof a.userId === "string" &&
+    typeof a.email === "string" &&
+    typeof a.fullName === "string" &&
+    typeof a.orgId === "string" &&
+    typeof a.assignedBySuperId === "string" &&
+    typeof a.assignedAtIso === "string"
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id || !ALLOWED_ROLES.has(role)) {
+    return withTrace(403, traceId, { error: "admin or super_admin role required." });
+  }
+
+  const adapterResult = getLicensingAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  const assignments = await adapterResult.adapter.getAllAssignments();
+  return withTrace(200, traceId, { assignments, total: assignments.length });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id || !ALLOWED_ROLES.has(role)) {
+    return withTrace(403, traceId, { error: "admin or super_admin role required." });
+  }
+
+  const adapterResult = getLicensingAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withTrace(400, traceId, { error: "Invalid JSON body." });
+  }
+
+  if (!isAssignment(body)) {
+    return withTrace(400, traceId, { error: "Invalid TeacherAssignmentRecord payload." });
+  }
+
+  const assignment = await adapterResult.adapter.upsertAssignment(body);
+  return withTrace(200, traceId, { assignment });
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id || !ALLOWED_ROLES.has(role)) {
+    return withTrace(403, traceId, { error: "admin or super_admin role required." });
+  }
+
+  const adapterResult = getLicensingAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  const id = new URL(request.url).searchParams.get("id")?.trim();
+  if (!id) {
+    return withTrace(400, traceId, { error: "id query param is required." });
+  }
+
+  await adapterResult.adapter.deleteAssignment(id);
+  return withTrace(200, traceId, { deleted: true, id });
+}

--- a/app/api/licensing/tenants/route.ts
+++ b/app/api/licensing/tenants/route.ts
@@ -1,0 +1,99 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import { parseAppRole } from "@/lib/auth/userRole";
+import { getLicensingAdapter } from "@/lib/licensing/dynamoAdapter";
+import type { LicenseTenant } from "@/lib/licensing/types";
+import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
+
+export const runtime = "nodejs";
+
+function withTrace(status: number, traceId: string, body: unknown): Response {
+  return NextResponse.json(body, { status, headers: { [TRACE_HEADER]: traceId } });
+}
+
+function isLicenseTenant(value: unknown): value is LicenseTenant {
+  if (!value || typeof value !== "object") return false;
+  const t = value as Partial<LicenseTenant>;
+  return (
+    typeof t.id === "string" &&
+    typeof t.name === "string" &&
+    (t.type === "trial" || t.type === "institutional" || t.type === "enterprise") &&
+    (t.status === "active" || t.status === "expired" || t.status === "suspended") &&
+    typeof t.startsAtIso === "string" &&
+    typeof t.seatCount === "number" &&
+    typeof t.contactEmail === "string" &&
+    typeof t.createdAtIso === "string" &&
+    typeof t.createdBySuperAdminId === "string"
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id || role !== "super_admin") {
+    return withTrace(403, traceId, { error: "super_admin role required." });
+  }
+
+  const adapterResult = getLicensingAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  const tenants = await adapterResult.adapter.getAllTenants();
+  return withTrace(200, traceId, { tenants, total: tenants.length });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id || role !== "super_admin") {
+    return withTrace(403, traceId, { error: "super_admin role required." });
+  }
+
+  const adapterResult = getLicensingAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withTrace(400, traceId, { error: "Invalid JSON body." });
+  }
+
+  if (!isLicenseTenant(body)) {
+    return withTrace(400, traceId, { error: "Invalid LicenseTenant payload." });
+  }
+
+  const tenant = await adapterResult.adapter.upsertTenant(body);
+  return withTrace(200, traceId, { tenant });
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id || role !== "super_admin") {
+    return withTrace(403, traceId, { error: "super_admin role required." });
+  }
+
+  const adapterResult = getLicensingAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  const id = new URL(request.url).searchParams.get("id")?.trim();
+  if (!id) {
+    return withTrace(400, traceId, { error: "id query param is required." });
+  }
+
+  await adapterResult.adapter.deleteTenant(id);
+  return withTrace(200, traceId, { deleted: true, id });
+}

--- a/app/api/runtime/state/route.ts
+++ b/app/api/runtime/state/route.ts
@@ -1,0 +1,104 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import { parseAppRole } from "@/lib/auth/userRole";
+import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
+import { getRuntimeStateAdapter } from "@/lib/runtime/dynamoAdapter";
+import type { RuntimeState } from "@/lib/runtime/engine/reducer";
+
+export const runtime = "nodejs";
+
+const LEARNER_ROLES = new Set(["student_independent", "student_enrolled", "adult_learner"]);
+const FACILITATOR_ROLES = new Set(["teacher", "professional_development"]);
+
+function withTrace(status: number, traceId: string, body: unknown): Response {
+  return NextResponse.json(body, { status, headers: { [TRACE_HEADER]: traceId } });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return withTrace(403, traceId, { error: "Authorized role required." });
+  }
+
+  const adapterResult = getRuntimeStateAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  const requestedLearnerId = new URL(request.url).searchParams.get("learnerId")?.trim();
+  let learnerId: string;
+
+  if (LEARNER_ROLES.has(role)) {
+    if (requestedLearnerId && requestedLearnerId !== user.id) {
+      return withTrace(403, traceId, { error: "Learners can only access their own state." });
+    }
+    learnerId = user.id;
+  } else if (FACILITATOR_ROLES.has(role) || role === "admin" || role === "super_admin") {
+    if (!requestedLearnerId) {
+      return withTrace(400, traceId, { error: "learnerId is required." });
+    }
+    learnerId = requestedLearnerId;
+  } else {
+    return withTrace(403, traceId, { error: "Authorized role required." });
+  }
+
+  const state = await adapterResult.adapter.read(learnerId);
+  return withTrace(200, traceId, { learnerId, state });
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return withTrace(403, traceId, { error: "Authorized role required." });
+  }
+
+  const adapterResult = getRuntimeStateAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withTrace(400, traceId, { error: "Invalid JSON body." });
+  }
+
+  if (!body || typeof body !== "object") {
+    return withTrace(400, traceId, { error: "Request body must be an object." });
+  }
+
+  const { learnerId, state } = body as { learnerId?: unknown; state?: unknown };
+
+  if (typeof learnerId !== "string" || !learnerId.trim()) {
+    return withTrace(400, traceId, { error: "learnerId is required." });
+  }
+
+  if (!state || typeof state !== "object") {
+    return withTrace(400, traceId, { error: "state is required." });
+  }
+
+  if (LEARNER_ROLES.has(role) && learnerId !== user.id) {
+    return withTrace(403, traceId, { error: "Learners can only write their own state." });
+  }
+
+  const allowed =
+    LEARNER_ROLES.has(role) ||
+    FACILITATOR_ROLES.has(role) ||
+    role === "admin" ||
+    role === "super_admin";
+
+  if (!allowed) {
+    return withTrace(403, traceId, { error: "Authorized role required." });
+  }
+
+  await adapterResult.adapter.write(learnerId, state as RuntimeState);
+  return withTrace(200, traceId, { learnerId, saved: true });
+}

--- a/app/api/standards/config/route.ts
+++ b/app/api/standards/config/route.ts
@@ -1,0 +1,90 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import { parseAppRole } from "@/lib/auth/userRole";
+import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
+import type { StandardDescriptor } from "@/lib/standards/contracts/types";
+import { getStandardsAdapter } from "@/lib/standards/dynamoAdapter";
+import { DEFAULT_STANDARDS } from "@/lib/standards/verifier/localVerifier";
+
+export const runtime = "nodejs";
+
+const WRITE_ROLES = new Set(["admin", "super_admin"]);
+
+function withTrace(status: number, traceId: string, body: unknown): Response {
+  return NextResponse.json(body, { status, headers: { [TRACE_HEADER]: traceId } });
+}
+
+function isStandardDescriptorArray(value: unknown): value is StandardDescriptor[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      typeof item.id === "string" &&
+      typeof item.title === "string" &&
+      Array.isArray(item.requiredKeywords) &&
+      item.requiredKeywords.every((k: unknown) => typeof k === "string")
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return withTrace(403, traceId, { error: "Authorized role required." });
+  }
+
+  const adapterResult = getStandardsAdapter();
+  if (!adapterResult.available) {
+    // Return defaults when backend is unconfigured
+    return withTrace(200, traceId, {
+      standards: DEFAULT_STANDARDS,
+      source: "default"
+    });
+  }
+
+  const stored = await adapterResult.adapter.readConfig();
+  return withTrace(200, traceId, {
+    standards: stored ?? DEFAULT_STANDARDS,
+    source: stored ? "database" : "default"
+  });
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return withTrace(403, traceId, { error: "Authorized role required." });
+  }
+
+  if (!WRITE_ROLES.has(role)) {
+    return withTrace(403, traceId, { error: "admin or super_admin role required." });
+  }
+
+  const adapterResult = getStandardsAdapter();
+  if (!adapterResult.available) {
+    return withTrace(503, traceId, { error: adapterResult.reason });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withTrace(400, traceId, { error: "Invalid JSON body." });
+  }
+
+  const standards = (body as { standards?: unknown })?.standards ?? body;
+  if (!isStandardDescriptorArray(standards)) {
+    return withTrace(400, traceId, {
+      error: "Body must be an array (or { standards: [...] }) of StandardDescriptor objects."
+    });
+  }
+
+  await adapterResult.adapter.writeConfig(standards);
+  return withTrace(200, traceId, { saved: true, count: standards.length });
+}

--- a/lib/licensing/dynamoAdapter.ts
+++ b/lib/licensing/dynamoAdapter.ts
@@ -1,0 +1,126 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+  DeleteCommand
+} from "@aws-sdk/lib-dynamodb";
+
+import { readAwsCredentials, readAwsRegion } from "@/lib/cloud/awsEnv";
+import type { LicenseTenant, TeacherAssignmentRecord } from "@/lib/licensing/types";
+
+function read(name: string): string | undefined {
+  const v = process.env[name]?.trim();
+  return v?.length ? v : undefined;
+}
+
+export type LicensingAdapterResult =
+  | { available: false; reason: string }
+  | { available: true; adapter: LicensingAdapter };
+
+export interface LicensingAdapter {
+  getAllTenants(): Promise<LicenseTenant[]>;
+  getTenant(id: string): Promise<LicenseTenant | null>;
+  upsertTenant(tenant: LicenseTenant): Promise<LicenseTenant>;
+  deleteTenant(id: string): Promise<void>;
+  getAllAssignments(): Promise<TeacherAssignmentRecord[]>;
+  upsertAssignment(assignment: TeacherAssignmentRecord): Promise<TeacherAssignmentRecord>;
+  deleteAssignment(id: string): Promise<void>;
+}
+
+export function getLicensingAdapter(): LicensingAdapterResult {
+  const table = read("AWS_DYNAMODB_LICENSING_TABLE");
+  const region = readAwsRegion();
+
+  if (!table) {
+    return { available: false, reason: "AWS_DYNAMODB_LICENSING_TABLE is not set." };
+  }
+  if (!region) {
+    return { available: false, reason: "AWS_REGION is not set." };
+  }
+
+  const client = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region, credentials: readAwsCredentials() })
+  );
+
+  return {
+    available: true,
+    adapter: {
+      async getAllTenants(): Promise<LicenseTenant[]> {
+        const result = await client.send(
+          new ScanCommand({
+            TableName: table,
+            FilterExpression: "begins_with(pk, :prefix)",
+            ExpressionAttributeValues: { ":prefix": "tenant#" }
+          })
+        );
+        return (result.Items ?? []).map(({ pk, sk, ...rest }) => {
+          void pk; void sk;
+          return rest as LicenseTenant;
+        });
+      },
+
+      async getTenant(id: string): Promise<LicenseTenant | null> {
+        const result = await client.send(
+          new GetCommand({ TableName: table, Key: { pk: `tenant#${id}`, sk: "metadata" } })
+        );
+        if (!result.Item) return null;
+        const { pk, sk, ...rest } = result.Item;
+        void pk; void sk;
+        return rest as LicenseTenant;
+      },
+
+      async upsertTenant(tenant: LicenseTenant): Promise<LicenseTenant> {
+        await client.send(
+          new PutCommand({
+            TableName: table,
+            Item: { pk: `tenant#${tenant.id}`, sk: "metadata", ...tenant }
+          })
+        );
+        return tenant;
+      },
+
+      async deleteTenant(id: string): Promise<void> {
+        await client.send(
+          new DeleteCommand({ TableName: table, Key: { pk: `tenant#${id}`, sk: "metadata" } })
+        );
+      },
+
+      async getAllAssignments(): Promise<TeacherAssignmentRecord[]> {
+        const result = await client.send(
+          new ScanCommand({
+            TableName: table,
+            FilterExpression: "begins_with(pk, :prefix)",
+            ExpressionAttributeValues: { ":prefix": "assignment#" }
+          })
+        );
+        return (result.Items ?? []).map(({ pk, sk, ...rest }) => {
+          void pk; void sk;
+          return rest as TeacherAssignmentRecord;
+        });
+      },
+
+      async upsertAssignment(
+        assignment: TeacherAssignmentRecord
+      ): Promise<TeacherAssignmentRecord> {
+        await client.send(
+          new PutCommand({
+            TableName: table,
+            Item: { pk: `assignment#${assignment.id}`, sk: "metadata", ...assignment }
+          })
+        );
+        return assignment;
+      },
+
+      async deleteAssignment(id: string): Promise<void> {
+        await client.send(
+          new DeleteCommand({
+            TableName: table,
+            Key: { pk: `assignment#${id}`, sk: "metadata" }
+          })
+        );
+      }
+    }
+  };
+}

--- a/lib/runtime/dynamoAdapter.ts
+++ b/lib/runtime/dynamoAdapter.ts
@@ -1,0 +1,62 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+
+import { readAwsCredentials, readAwsRegion } from "@/lib/cloud/awsEnv";
+import type { RuntimeState } from "@/lib/runtime/engine/reducer";
+import { createInitialRuntimeState } from "@/lib/runtime/engine/reducer";
+
+function read(name: string): string | undefined {
+  const v = process.env[name]?.trim();
+  return v?.length ? v : undefined;
+}
+
+export type RuntimeStateResult =
+  | { available: false; reason: string }
+  | { available: true; adapter: RuntimeStateAdapter };
+
+export interface RuntimeStateAdapter {
+  read(learnerId: string): Promise<RuntimeState>;
+  write(learnerId: string, state: RuntimeState): Promise<void>;
+}
+
+export function getRuntimeStateAdapter(): RuntimeStateResult {
+  const table = read("AWS_DYNAMODB_RUNTIME_TABLE");
+  const region = readAwsRegion();
+
+  if (!table) {
+    return { available: false, reason: "AWS_DYNAMODB_RUNTIME_TABLE is not set." };
+  }
+  if (!region) {
+    return { available: false, reason: "AWS_REGION is not set." };
+  }
+
+  const client = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region, credentials: readAwsCredentials() })
+  );
+
+  return {
+    available: true,
+    adapter: {
+      async read(learnerId: string): Promise<RuntimeState> {
+        const result = await client.send(
+          new GetCommand({ TableName: table, Key: { pk: `runtime#${learnerId}`, sk: "state" } })
+        );
+        if (!result.Item) {
+          return createInitialRuntimeState();
+        }
+        const { pk, sk, ...rest } = result.Item;
+        void pk; void sk;
+        return rest as RuntimeState;
+      },
+
+      async write(learnerId: string, state: RuntimeState): Promise<void> {
+        await client.send(
+          new PutCommand({
+            TableName: table,
+            Item: { pk: `runtime#${learnerId}`, sk: "state", ...state }
+          })
+        );
+      }
+    }
+  };
+}

--- a/lib/standards/dynamoAdapter.ts
+++ b/lib/standards/dynamoAdapter.ts
@@ -1,0 +1,63 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+
+import { readAwsCredentials, readAwsRegion } from "@/lib/cloud/awsEnv";
+import type { StandardDescriptor } from "@/lib/standards/contracts/types";
+
+function read(name: string): string | undefined {
+  const v = process.env[name]?.trim();
+  return v?.length ? v : undefined;
+}
+
+export type StandardsAdapterResult =
+  | { available: false; reason: string }
+  | { available: true; adapter: StandardsAdapter };
+
+export interface StandardsAdapter {
+  readConfig(): Promise<StandardDescriptor[] | null>;
+  writeConfig(standards: StandardDescriptor[]): Promise<void>;
+}
+
+export function getStandardsAdapter(): StandardsAdapterResult {
+  const table = read("AWS_DYNAMODB_STANDARDS_TABLE");
+  const region = readAwsRegion();
+
+  if (!table) {
+    return { available: false, reason: "AWS_DYNAMODB_STANDARDS_TABLE is not set." };
+  }
+  if (!region) {
+    return { available: false, reason: "AWS_REGION is not set." };
+  }
+
+  const client = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region, credentials: readAwsCredentials() })
+  );
+
+  return {
+    available: true,
+    adapter: {
+      async readConfig(): Promise<StandardDescriptor[] | null> {
+        const result = await client.send(
+          new GetCommand({ TableName: table, Key: { pk: "standards", sk: "config" } })
+        );
+        if (!result.Item) return null;
+        const { pk, sk, standards } = result.Item as {
+          pk: unknown;
+          sk: unknown;
+          standards: StandardDescriptor[];
+        };
+        void pk; void sk;
+        return standards ?? null;
+      },
+
+      async writeConfig(standards: StandardDescriptor[]): Promise<void> {
+        await client.send(
+          new PutCommand({
+            TableName: table,
+            Item: { pk: "standards", sk: "config", standards }
+          })
+        );
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- **#162 Runtime state**: `GET/PUT /api/runtime/state` with DynamoDB backend (`AWS_DYNAMODB_RUNTIME_TABLE`). Per-learner state, role-gated (learners own state only; facilitators/admin can read any).
- **#163 Licensing**: `GET/POST/DELETE /api/licensing/tenants` (super_admin only) and `GET/POST/DELETE /api/licensing/assignments` (admin/super_admin). DynamoDB backend (`AWS_DYNAMODB_LICENSING_TABLE`).
- **#165 Standards config**: `GET /api/standards/config` (any authed role; falls back to DEFAULT_STANDARDS when unconfigured) and `PUT /api/standards/config` (admin/super_admin). DynamoDB backend (`AWS_DYNAMODB_STANDARDS_TABLE`).
- `.env.example` updated with the three new table env vars.

All routes return HTTP 503 when the corresponding table env var is unset (graceful degradation). Role-auth and trace-id follow existing ledger patterns.

## Test plan
- [ ] Lint + typecheck pass
- [ ] `GET /api/runtime/state?learnerId=x` returns state for super_admin; 403 for learner requesting another learner's state
- [ ] `GET /api/standards/config` returns DEFAULT_STANDARDS when `AWS_DYNAMODB_STANDARDS_TABLE` is unset
- [ ] `POST /api/licensing/tenants` returns 403 for non-super_admin

Closes #162, #163, #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)