### PR TITLE
Add HTTP security headers and wire runtime flag to onboarding tour

### DIFF
--- a/lib/onboarding/resolveSteps.ts
+++ b/lib/onboarding/resolveSteps.ts
@@ -1,17 +1,25 @@
 import type { AppRole } from "@/lib/auth/roles";
-import { PHASE1_FEATURE_FLAG_KEYS, type Phase1FeatureFlagKey } from "@/lib/config/featureFlags";
+import {
+  PHASE1_FEATURE_FLAG_KEYS,
+  PHASE3_FEATURE_FLAG_KEYS,
+  type Phase1FeatureFlagKey,
+  type Phase3FeatureFlagKey
+} from "@/lib/config/featureFlags";
 import { ROLE_TOUR_STEPS, type TourStep } from "./tourSteps";
+
+export type TourFlagKey = Phase1FeatureFlagKey | Phase3FeatureFlagKey;
 
 export type TourContext = {
   role: AppRole;
-  flags: Readonly<Record<Phase1FeatureFlagKey, boolean>>;
+  flags: Readonly<Record<TourFlagKey, boolean>>;
 };
 
-export function getClientFlagSnapshot(): Readonly<Record<Phase1FeatureFlagKey, boolean>> {
-  return PHASE1_FEATURE_FLAG_KEYS.reduce((accumulator, key) => {
-    accumulator[key] = process.env[key] === "true";
+export function getClientFlagSnapshot(): Readonly<Record<TourFlagKey, boolean>> {
+  const allKeys = [...PHASE1_FEATURE_FLAG_KEYS, ...PHASE3_FEATURE_FLAG_KEYS];
+  return allKeys.reduce((accumulator, key) => {
+    accumulator[key as TourFlagKey] = process.env[key] === "true";
     return accumulator;
-  }, {} as Record<Phase1FeatureFlagKey, boolean>);
+  }, {} as Record<TourFlagKey, boolean>);
 }
 
 export function resolveTourSteps({ role, flags }: TourContext): TourStep[] {
@@ -22,6 +30,6 @@ export function resolveTourSteps({ role, flags }: TourContext): TourStep[] {
       return true;
     }
 
-    return flags[step.requiredFlag];
+    return flags[step.requiredFlag as TourFlagKey] === true;
   });
 }

--- a/lib/onboarding/tourSteps.ts
+++ b/lib/onboarding/tourSteps.ts
@@ -1,23 +1,23 @@
 import type { AppRole } from "@/lib/auth/roles";
-import type { Phase1FeatureFlagKey } from "@/lib/config/featureFlags";
+import type { Phase1FeatureFlagKey, Phase3FeatureFlagKey } from "@/lib/config/featureFlags";
 
 export type TourStep = {
   id: string;
   selector: string;
   title: string;
   body: string;
-  requiredFlag?: Phase1FeatureFlagKey;
+  requiredFlag?: Phase1FeatureFlagKey | Phase3FeatureFlagKey;
 };
 
 export const ROLE_TOUR_STEPS: Readonly<Record<AppRole, readonly TourStep[]>> = {
   student_independent: [
     { id: "nav", selector: "[data-tour='primary-nav']", title: "Navigation", body: "Use left navigation to move through PLE, missions, and studio." },
     { id: "home", selector: "[data-tour='page-title']", title: "Home", body: "This is your current workspace context." },
-    { id: "mission", selector: "[data-tour='mission-draft']", title: "Mission Draft", body: "Capture your mission objective before moving into Studio." },
-    { id: "mission-actions", selector: "[data-tour='mission-actions']", title: "Mission Actions", body: "Start or submit mission lifecycle events from PLE." },
-    { id: "studio", selector: "[data-tour='studio-entry']", title: "Studio Path", body: "Move to Studio to transform your mission draft into an artifact." },
-    { id: "artifact-save", selector: "[data-tour='artifact-save']", title: "Artifact Save", body: "Save artifact content to the local evidence ledger." },
-    { id: "verification", selector: "[data-tour='verification-summary']", title: "Verification", body: "Review standards verification summary after saving." },
+    { id: "mission", selector: "[data-tour='mission-draft']", title: "Mission Draft", body: "Capture your mission objective before moving into Studio.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "mission-actions", selector: "[data-tour='mission-actions']", title: "Mission Actions", body: "Start or submit mission lifecycle events from PLE.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "studio", selector: "[data-tour='studio-entry']", title: "Studio Path", body: "Move to Studio to transform your mission draft into an artifact.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "artifact-save", selector: "[data-tour='artifact-save']", title: "Artifact Save", body: "Save artifact content to the local evidence ledger.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "verification", selector: "[data-tour='verification-summary']", title: "Verification", body: "Review standards verification summary after saving.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
     { id: "help", selector: "[data-tour='help-menu']", title: "Help Menu", body: "Use Help to restart this tour at any time." },
     { id: "core", selector: "[data-tour='core-mount']", title: "Core Mount", body: "Legacy core screens are available during migration.", requiredFlag: "NEXT_PUBLIC_ENABLE_CORE_VITE_MOUNT" }
   ],
@@ -30,8 +30,8 @@ export const ROLE_TOUR_STEPS: Readonly<Record<AppRole, readonly TourStep[]>> = {
   adult_learner: [
     { id: "nav", selector: "[data-tour='primary-nav']", title: "Navigation", body: "Use your adult learner navigation to move from goals to evidence." },
     { id: "home", selector: "[data-tour='page-title']", title: "Adult Workspace", body: "Track applied objectives and professional artifacts from this home view." },
-    { id: "mission", selector: "[data-tour='mission-draft']", title: "Current Goal", body: "Capture your current objective and launch a mission cycle." },
-    { id: "studio", selector: "[data-tour='studio-entry']", title: "Studio", body: "Move into Studio to finalize your adult learning artifact." },
+    { id: "mission", selector: "[data-tour='mission-draft']", title: "Current Goal", body: "Capture your current objective and launch a mission cycle.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "studio", selector: "[data-tour='studio-entry']", title: "Studio", body: "Move into Studio to finalize your adult learning artifact.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
     { id: "help", selector: "[data-tour='help-menu']", title: "Help Menu", body: "Restart this tour at any time from Help." }
   ],
   teacher: [

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,48 @@
 /** @type {import('next').NextConfig} */
+
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-XSS-Protection", value: "1; mode=block" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()"
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload"
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.accounts.dev https://*.clerk.accounts.dev https://clerk.com https://*.clerk.com",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "img-src 'self' data: blob: https://*.clerk.com https://img.clerk.com",
+      "font-src 'self' https://fonts.gstatic.com",
+      "connect-src 'self' https://*.clerk.accounts.dev https://api.clerk.com https://clerk.com wss:",
+      "frame-src 'none'",
+      "object-src 'none'",
+      "base-uri 'self'"
+    ].join("; ")
+  }
+];
+
 const nextConfig = {
   reactStrictMode: true,
   eslint: {
-    dirs: ['app', 'lib'],
+    dirs: ["app", "lib"]
   },
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes
+        source: "/:path*",
+        headers: securityHeaders
+      }
+    ];
+  }
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- **#175 Security headers**: Adds `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`, and a `Content-Security-Policy` (with Clerk endpoints allowlisted) to all routes via `next.config.js`.
- **#170 Onboarding**: Extends `TourStep.requiredFlag` to accept Phase3 flag keys (`NEXT_PUBLIC_ENABLE_RUNTIME`). Updates `resolveTourSteps()` and `getClientFlagSnapshot()` to read both Phase1 and Phase3 flags. Runtime-dependent tour steps (mission-draft, mission-actions, studio, artifact-save, verification) are now hidden when `NEXT_PUBLIC_ENABLE_RUNTIME` is not set.

## Test plan
- [ ] `npm run lint && npm run typecheck` pass
- [ ] Response headers include `X-Frame-Options: DENY` and `Content-Security-Policy` on all routes
- [ ] Tour steps for mission/studio/artifact/verification are filtered out when `NEXT_PUBLIC_ENABLE_RUNTIME` is false
- [ ] Tour steps appear when `NEXT_PUBLIC_ENABLE_RUNTIME=true`

Closes #170, #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)