### PR TITLE
Complete mission lifecycle and add offline service worker

### DIFF
--- a/app/api/offline/status/route.ts
+++ b/app/api/offline/status/route.ts
@@ -14,7 +14,7 @@ export function GET(request: Request): Response {
   }
 
   return NextResponse.json(
-    { status: "ready", mode: "cache-planned" },
+    { status: "ready", mode: "service-worker", swPath: "/sw.js" },
     { status: 200, headers: { [TRACE_HEADER]: traceId } }
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ClerkProvider } from "@clerk/nextjs";
 import type { Metadata } from "next";
 
+import ServiceWorkerRegistrar from "@/components/offline/ServiceWorkerRegistrar";
 import { getConfiguredPublishableKey, sanitizePublicUrl } from "@/lib/config/envGuards";
 
 import "./globals.css";
@@ -9,6 +10,8 @@ export const metadata: Metadata = {
   title: "RootWork LOS",
   description: "RootWork Learning Operating System front door shell"
 };
+
+const offlineEnabled = process.env.NEXT_PUBLIC_ENABLE_OFFLINE === "true";
 
 export default function RootLayout({
   children
@@ -22,7 +25,10 @@ export default function RootLayout({
   if (!publishableKey) {
     return (
       <html lang="en">
-        <body>{children}</body>
+        <body>
+          {offlineEnabled && <ServiceWorkerRegistrar />}
+          {children}
+        </body>
       </html>
     );
   }
@@ -30,7 +36,10 @@ export default function RootLayout({
   return (
     <ClerkProvider publishableKey={publishableKey} signInUrl={signInUrl ?? undefined} signUpUrl={signUpUrl ?? undefined}>
       <html lang="en">
-        <body>{children}</body>
+        <body>
+          {offlineEnabled && <ServiceWorkerRegistrar />}
+          {children}
+        </body>
       </html>
     </ClerkProvider>
   );

--- a/components/missions/MissionsList.tsx
+++ b/components/missions/MissionsList.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 
 import type { RuntimeMission, RuntimeMissionStage, VerificationEvent } from "@/lib/runtime/contracts/types";
-import { readRuntimeState } from "@/lib/runtime/engine/store";
+import { dispatchRuntimeEvent, readRuntimeState } from "@/lib/runtime/engine/store";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,9 +52,14 @@ function StageBadge({ stage }: { stage: RuntimeMissionStage }) {
   );
 }
 
-function MissionCard({ mission, artifactCount, verifications }: MissionRow) {
+function MissionCard({
+  mission,
+  artifactCount,
+  verifications,
+  onAdvance,
+}: MissionRow & { onAdvance: (missionId: string, stage: RuntimeMissionStage) => void }) {
   return (
-    <article className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+    <article className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-5 shadow-sm" data-tour="mission-actions">
       <div className="flex items-start justify-between gap-2">
         <h2 className="text-base font-semibold text-slate-900 leading-snug">{mission.title}</h2>
         <StageBadge stage={mission.stage} />
@@ -77,13 +82,42 @@ function MissionCard({ mission, artifactCount, verifications }: MissionRow) {
         </div>
       </dl>
 
-      <div className="mt-auto pt-1">
-        <Link
-          href="/app/studio"
-          className="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-slate-700 transition-colors"
-        >
-          Open Studio &rarr;
-        </Link>
+      <div className="mt-auto flex flex-wrap gap-2 pt-1">
+        {mission.stage === "not_started" && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500 transition-colors"
+            onClick={() => onAdvance(mission.id, "in_progress")}
+          >
+            Start Mission
+          </button>
+        )}
+
+        {mission.stage === "in_progress" && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-500 transition-colors"
+            onClick={() => onAdvance(mission.id, "submitted")}
+          >
+            Submit for Review
+          </button>
+        )}
+
+        {mission.stage !== "verified" && (
+          <Link
+            href="/app/studio"
+            className="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-slate-700 transition-colors"
+            data-tour="studio-entry"
+          >
+            Open Studio &rarr;
+          </Link>
+        )}
+
+        {mission.stage === "verified" && (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700">
+            ✓ Verified
+          </span>
+        )}
       </div>
     </article>
   );
@@ -92,7 +126,6 @@ function MissionCard({ mission, artifactCount, verifications }: MissionRow) {
 function EmptyState() {
   return (
     <div className="flex flex-col items-center gap-4 rounded-xl border-2 border-dashed border-slate-200 bg-slate-50 px-8 py-14 text-center">
-      {/* Illustrated placeholder */}
       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-200 text-3xl" aria-hidden="true">
         🗺️
       </div>
@@ -135,11 +168,8 @@ function RuntimeDisabledBanner() {
 export default function MissionsList() {
   const runtimeEnabled = Boolean(process.env.NEXT_PUBLIC_ENABLE_RUNTIME);
 
-  // Read runtime state once on mount (localStorage is client-only, so we use
-  // a lazy initialiser inside useState rather than useMemo to avoid SSR issues)
-  const [rows] = useState<MissionRow[]>(() => {
+  const [rows, setRows] = useState<MissionRow[]>(() => {
     const state = readRuntimeState();
-
     return Object.values(state.missions).map((mission) => ({
       mission,
       artifactCount: Object.values(state.artifacts).filter((a) => a.missionId === mission.id).length,
@@ -148,6 +178,18 @@ export default function MissionsList() {
   });
 
   const hasMissions = rows.length > 0;
+
+  function handleAdvance(missionId: string, stage: RuntimeMissionStage) {
+    const updatedAtIso = new Date().toISOString();
+    dispatchRuntimeEvent({ type: "MISSION_ADVANCED", missionId, stage, updatedAtIso });
+    setRows((prev) =>
+      prev.map((row) =>
+        row.mission.id === missionId
+          ? { ...row, mission: { ...row.mission, stage, updatedAtIso } }
+          : row
+      )
+    );
+  }
 
   return (
     <section className="space-y-6">
@@ -166,6 +208,7 @@ export default function MissionsList() {
           <Link
             href="/app"
             className="inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors"
+            data-tour="mission-draft"
           >
             + Start New Mission
           </Link>
@@ -184,6 +227,7 @@ export default function MissionsList() {
               mission={mission}
               artifactCount={artifactCount}
               verifications={verifications}
+              onAdvance={handleAdvance}
             />
           ))}
         </div>

--- a/components/offline/ServiceWorkerRegistrar.tsx
+++ b/components/offline/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers the service worker at /sw.js when the browser supports it.
+ * Only mounted when NEXT_PUBLIC_ENABLE_OFFLINE=true (checked at the call site
+ * in app/layout.tsx). The component renders nothing visible.
+ */
+export default function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+
+    navigator.serviceWorker
+      .register("/sw.js", { scope: "/" })
+      .then((registration) => {
+        console.info("[SW] Registered:", registration.scope);
+      })
+      .catch((err) => {
+        console.warn("[SW] Registration failed:", err);
+      });
+  }, []);
+
+  return null;
+}

--- a/components/reviews/ReviewQueue.tsx
+++ b/components/reviews/ReviewQueue.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { isDbLedgerFlagEnabled } from "@/lib/ledger/flags";
 import { localLedgerAdapter } from "@/lib/ledger/adapter";
 import type { RuntimeArtifact } from "@/lib/runtime/contracts/types";
 import ReviewCard from "./ReviewCard";
 
 type ReviewItem = {
   id: string;
+  missionId: string;
+  learnerId: string;
   artifactTitle: string;
   learnerName: string;
   submittedAt: string;
@@ -25,18 +28,47 @@ function formatDate(isoString: string): string {
   }
 }
 
-export default function ReviewQueue() {
-  const [items, setItems] = useState<ReviewItem[]>([]);
-  const [loaded, setLoaded] = useState(false);
+async function fetchLedgerRecords(): Promise<ReviewItem[]> {
+  if (isDbLedgerFlagEnabled()) {
+    try {
+      const res = await fetch("/api/ledger/records");
+      if (res.ok) {
+        const data = (await res.json()) as { records?: unknown[] };
+        const records = data.records ?? [];
+        return records
+          .filter(
+            (r): r is Record<string, unknown> =>
+              !!r && typeof r === "object" && (r as Record<string, unknown>).type === "artifact"
+          )
+          .map((r) => {
+            const payload = (r.payload ?? {}) as RuntimeArtifact;
+            return {
+              id: r.id as string,
+              missionId: payload.missionId ?? (r.missionId as string) ?? "",
+              learnerId: (r.learnerId as string) ?? "",
+              artifactTitle: payload.missionId
+                ? `Artifact: Mission ${payload.missionId}`
+                : "Untitled Artifact",
+              learnerName: (r.learnerId as string) ?? "Unknown",
+              submittedAt: formatDate((r.createdAtIso as string) ?? ""),
+              flagged: false,
+            };
+          });
+      }
+    } catch {
+      // fall through to local adapter
+    }
+  }
 
-  useEffect(() => {
-    const records = localLedgerAdapter.readAll();
-    const artifactRecords = records.filter((r) => r.type === "artifact");
-
-    const derived: ReviewItem[] = artifactRecords.map((r) => {
+  const records = localLedgerAdapter.readAll();
+  return records
+    .filter((r) => r.type === "artifact")
+    .map((r) => {
       const payload = r.payload as RuntimeArtifact;
       return {
         id: r.id,
+        missionId: payload.missionId ?? r.missionId,
+        learnerId: r.learnerId,
         artifactTitle: payload.missionId
           ? `Artifact: Mission ${payload.missionId}`
           : "Untitled Artifact",
@@ -45,13 +77,56 @@ export default function ReviewQueue() {
         flagged: false,
       };
     });
+}
 
-    setItems(derived);
-    setLoaded(true);
+async function approveMission(learnerId: string, missionId: string): Promise<void> {
+  try {
+    const getRes = await fetch(
+      `/api/runtime/state?learnerId=${encodeURIComponent(learnerId)}`
+    );
+    if (!getRes.ok) return;
+
+    const { state } = (await getRes.json()) as { state?: Record<string, unknown> };
+    if (!state) return;
+
+    const missions = (state.missions ?? {}) as Record<string, Record<string, unknown>>;
+    if (!missions[missionId]) return;
+
+    missions[missionId] = {
+      ...missions[missionId],
+      stage: "verified",
+      updatedAtIso: new Date().toISOString(),
+    };
+
+    await fetch("/api/runtime/state", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ learnerId, state: { ...state, missions } }),
+    });
+  } catch {
+    // Non-fatal: approval UI still removes the item from the queue.
+  }
+}
+
+export default function ReviewQueue() {
+  const [items, setItems] = useState<ReviewItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetchLedgerRecords()
+      .then((derived) => {
+        setItems(derived);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
   }, []);
 
-  function handleApprove(id: string) {
-    setItems((prev) => prev.filter((item) => item.id !== id));
+  async function handleApprove(id: string) {
+    const item = items.find((i) => i.id === id);
+    if (item) {
+      await approveMission(item.learnerId, item.missionId);
+    }
+    setItems((prev) => prev.filter((i) => i.id !== id));
   }
 
   function handleReturn(id: string) {
@@ -66,7 +141,9 @@ export default function ReviewQueue() {
 
   return (
     <section className="space-y-4">
-      <h1 className="text-2xl font-semibold" data-tour="page-title">Review Queue</h1>
+      <h1 className="text-2xl font-semibold" data-tour="page-title">
+        Review Queue
+      </h1>
       <p className="text-sm text-slate-700">
         Triage submitted artifacts. Approve, return for revision, or flag submissions needing
         attention.
@@ -77,9 +154,7 @@ export default function ReviewQueue() {
       {loaded && items.length === 0 && (
         <div className="rounded-lg border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
           <p className="font-medium text-slate-800">No artifacts pending review.</p>
-          <p className="mt-1">
-            Submissions appear here when learners save work in Studio.
-          </p>
+          <p className="mt-1">Submissions appear here when learners save work in Studio.</p>
         </div>
       )}
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,105 @@
+/**
+ * RootWork LOS Service Worker — offline-first caching (Phase 1)
+ *
+ * Strategy:
+ *   - Static assets (JS, CSS, fonts, images): cache-first
+ *   - API routes (/api/*): network-first, no cache
+ *   - Clerk authentication endpoints: network-only, never cached
+ *   - All other routes (Next.js pages): stale-while-revalidate
+ */
+
+const CACHE_VERSION = "rwfw-los-v1";
+const STATIC_CACHE = `${CACHE_VERSION}-static`;
+const PAGE_CACHE = `${CACHE_VERSION}-pages`;
+
+const NEVER_CACHE = [
+  "clerk.accounts.dev",
+  "clerk.com",
+  "/sign-in",
+  "/sign-up",
+  "/api/",
+];
+
+function shouldSkip(url) {
+  return NEVER_CACHE.some((pattern) => url.includes(pattern));
+}
+
+function isStaticAsset(url) {
+  return (
+    url.includes("/_next/static/") ||
+    url.includes("/fonts/") ||
+    /\.(woff2?|ttf|otf|png|jpg|jpeg|gif|svg|ico|webp)$/.test(url)
+  );
+}
+
+// Install: pre-cache the offline shell page if available
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => {
+      // Minimal pre-cache — just the root to support offline shell
+      return cache.addAll(["/"]).catch(() => {
+        // If pre-caching fails (dev mode, etc.), continue silently
+      });
+    })
+  );
+  self.skipWaiting();
+});
+
+// Activate: clean up old caches
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key.startsWith("rwfw-los-") && key !== STATIC_CACHE && key !== PAGE_CACHE)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+// Fetch: apply strategy based on request type
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = request.url;
+
+  // Only handle GET requests
+  if (request.method !== "GET") return;
+
+  // Skip Clerk and API routes entirely
+  if (shouldSkip(url)) return;
+
+  if (isStaticAsset(url)) {
+    // Cache-first for static assets
+    event.respondWith(
+      caches.open(STATIC_CACHE).then(async (cache) => {
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        const response = await fetch(request);
+        if (response.ok) {
+          cache.put(request, response.clone());
+        }
+        return response;
+      })
+    );
+    return;
+  }
+
+  // Stale-while-revalidate for page routes
+  event.respondWith(
+    caches.open(PAGE_CACHE).then(async (cache) => {
+      const cached = await cache.match(request);
+      const networkFetch = fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            cache.put(request, response.clone());
+          }
+          return response;
+        })
+        .catch(() => cached);
+
+      return cached ?? networkFetch;
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- **#173 Mission lifecycle**: Adds Start Mission and Submit for Review buttons to `MissionsList` with optimistic stage updates via `dispatchRuntimeEvent`. `ReviewQueue` now fetches artifacts via server ledger API (when available) and advances learner mission stage to `"verified"` via `PUT /api/runtime/state` on Approve.
- **#172 Offline-first caching**: Adds `public/sw.js` (service worker with cache-first for static assets, stale-while-revalidate for pages, bypass for Clerk/API), `ServiceWorkerRegistrar` client component mounted in root layout when `NEXT_PUBLIC_ENABLE_OFFLINE=true`, and updates `/api/offline/status` to report `mode: "service-worker"`.

## Test plan
- [ ] `npm run lint && npm run typecheck` pass
- [ ] Mission card shows "Start Mission" button when stage is `not_started`; clicking dispatches to `in_progress`
- [ ] Mission card shows "Submit for Review" when stage is `in_progress`
- [ ] Service worker registers at `/sw.js` when `NEXT_PUBLIC_ENABLE_OFFLINE=true`
- [ ] `GET /api/offline/status` returns `mode: "service-worker"` when offline flag is set

Closes #172, #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)