### PR TITLE
Fix CSP headers for production Clerk custom domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,11 +17,11 @@ const securityHeaders = [
     key: "Content-Security-Policy",
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.accounts.dev https://*.clerk.accounts.dev https://clerk.com https://*.clerk.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.rwfw-los.com https://*.clerk.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https://*.clerk.com https://img.clerk.com",
       "font-src 'self' https://fonts.gstatic.com",
-      "connect-src 'self' https://*.clerk.accounts.dev https://api.clerk.com https://clerk.com wss:",
+      "connect-src 'self' https://clerk.rwfw-los.com https://accounts.rwfw-los.com https://api.clerk.com wss:",
       "frame-src 'none'",
       "object-src 'none'",
       "base-uri 'self'"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `clerk.accounts.dev` test origins with production `clerk.rwfw-los.com` and `accounts.rwfw-los.com` in `script-src` and `connect-src` CSP directives
- Part of Clerk instance/key fix across RWFW-LOS and learning-hub

## Test plan
- [x] Both apps deployed to production with correct live Clerk key pairs
- [x] All Clerk DNS records added and verified (clerk.*, accounts.*, clkmail.*, DKIM)
- [x] Sign-in pages return HTTP 200 with `X-Clerk-Auth-Status: signed-out`

🤖 Generated with [Claude Code](https://claude.com/claude-code)