### PR TITLE
Add admin data retention and audit log features

### DIFF
--- a/app/api/super-admin/audit-log/route.ts
+++ b/app/api/super-admin/audit-log/route.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { currentUser } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import { parseAppRole } from "@/lib/auth/userRole";
+import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
+
+export const runtime = "nodejs";
+
+type AuditEntry = {
+  traceId: string;
+  eventType: string;
+  role: string;
+  orgId?: string;
+  actorId?: string;
+  severity: string;
+  metadata?: Record<string, unknown>;
+  createdAtIso: string;
+};
+
+const AUDIT_LOG_PATH = resolve("docs", "status", "audit-log.ndjson");
+
+async function readAuditLog(): Promise<AuditEntry[]> {
+  try {
+    const raw = await readFile(AUDIT_LOG_PATH, "utf8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+    const entries: AuditEntry[] = [];
+    for (const line of lines) {
+      try {
+        entries.push(JSON.parse(line) as AuditEntry);
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return entries.reverse(); // most recent first
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (role !== "super_admin") {
+    return NextResponse.json(
+      { error: "super_admin role required." },
+      { status: 403, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
+
+  const url = new URL(request.url);
+  const limitParam = url.searchParams.get("limit");
+  const limit = Math.min(parseInt(limitParam ?? "100", 10) || 100, 500);
+
+  const entries = await readAuditLog();
+  const page = entries.slice(0, limit);
+
+  return NextResponse.json(
+    { entries: page, total: entries.length, limit },
+    { status: 200, headers: { [TRACE_HEADER]: traceId } }
+  );
+}

--- a/app/app/retention/page.tsx
+++ b/app/app/retention/page.tsx
@@ -1,0 +1,18 @@
+import ForbiddenPanel from "@/components/app-shell/ForbiddenPanel";
+import DataRetentionManager from "@/components/admin/DataRetentionManager";
+import { getCurrentAppRole } from "@/lib/auth/currentRole";
+import { isRoleAllowedForPath } from "@/lib/auth/routeAccess";
+
+export default async function RetentionPage() {
+  const role = await getCurrentAppRole();
+
+  if (!role) {
+    return <ForbiddenPanel message="No valid role is assigned to your account." />;
+  }
+
+  if (!isRoleAllowedForPath("/app/retention", role)) {
+    return <ForbiddenPanel message="Data retention management is restricted to administrators." />;
+  }
+
+  return <DataRetentionManager />;
+}

--- a/app/app/super-admin/audit-log/page.tsx
+++ b/app/app/super-admin/audit-log/page.tsx
@@ -1,0 +1,13 @@
+import ForbiddenPanel from "@/components/app-shell/ForbiddenPanel";
+import AuditLogViewer from "@/components/super-admin/AuditLogViewer";
+import { getCurrentAppRole } from "@/lib/auth/currentRole";
+
+export default async function SuperAdminAuditLogPage() {
+  const role = await getCurrentAppRole();
+
+  if (role !== "super_admin") {
+    return <ForbiddenPanel message="Audit log is restricted to Super Admins." />;
+  }
+
+  return <AuditLogViewer />;
+}

--- a/components/admin/DataRetentionManager.tsx
+++ b/components/admin/DataRetentionManager.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+
+type RetentionResult = {
+  action: string;
+  purged: number;
+  doneAtIso: string;
+};
+
+export default function DataRetentionManager() {
+  const [cutoffDate, setCutoffDate] = useState("");
+  const [learnerId, setLearnerId] = useState("");
+  const [purgeStatus, setPurgeStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [deleteStatus, setDeleteStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handlePurgeBefore() {
+    if (!cutoffDate.trim()) {
+      setPurgeStatus({ type: "error", message: "Cutoff date is required." });
+      return;
+    }
+
+    const cutoffIso = new Date(cutoffDate).toISOString();
+    setLoading(true);
+    setPurgeStatus(null);
+
+    try {
+      const response = await fetch("/api/admin/retention", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "purge_before", cutoffIso }),
+      });
+
+      const payload = (await response.json()) as RetentionResult & { error?: string };
+
+      if (!response.ok) {
+        setPurgeStatus({ type: "error", message: payload.error ?? `Request failed (${response.status})` });
+        return;
+      }
+
+      setPurgeStatus({
+        type: "success",
+        message: `Purged ${payload.purged} record${payload.purged !== 1 ? "s" : ""} before ${cutoffDate}. Completed at ${new Date(payload.doneAtIso).toLocaleString()}.`,
+      });
+      setCutoffDate("");
+    } catch {
+      setPurgeStatus({ type: "error", message: "Network error. Please try again." });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDeleteLearner() {
+    if (!learnerId.trim()) {
+      setDeleteStatus({ type: "error", message: "Learner ID is required." });
+      return;
+    }
+
+    setLoading(true);
+    setDeleteStatus(null);
+
+    try {
+      const response = await fetch("/api/admin/retention", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "delete_learner", learnerId: learnerId.trim() }),
+      });
+
+      const payload = (await response.json()) as RetentionResult & { error?: string };
+
+      if (!response.ok) {
+        setDeleteStatus({ type: "error", message: payload.error ?? `Request failed (${response.status})` });
+        return;
+      }
+
+      setDeleteStatus({
+        type: "success",
+        message: `Deleted ${payload.purged} record${payload.purged !== 1 ? "s" : ""} for learner "${learnerId.trim()}". Completed at ${new Date(payload.doneAtIso).toLocaleString()}.`,
+      });
+      setLearnerId("");
+    } catch {
+      setDeleteStatus({ type: "error", message: "Network error. Please try again." });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <h1 className="text-2xl font-semibold" data-tour="page-title">Data Retention</h1>
+      <p className="text-sm text-slate-700" data-tour="page-description">
+        Manage learner data lifecycle and compliance with retention policies. These actions are permanent
+        and are recorded in the audit log.
+      </p>
+
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+        <p className="font-medium">Destructive operations</p>
+        <p className="mt-1">
+          Purge and delete actions permanently remove ledger records. Ensure DB ledger is enabled
+          ({" "}<code>NEXT_PUBLIC_ENABLE_DB_LEDGER=true</code>) before performing retention actions.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Purge Before Date */}
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-5">
+          <h2 className="font-semibold text-slate-900">Purge Records Before Date</h2>
+          <p className="mt-1 text-xs text-slate-600">
+            Permanently deletes all ledger records updated before the specified date. Used for data
+            retention schedule compliance.
+          </p>
+          <div className="mt-4 space-y-3">
+            <div>
+              <label htmlFor="cutoff-date" className="block text-xs font-medium text-slate-700">
+                Cutoff Date
+              </label>
+              <input
+                id="cutoff-date"
+                type="date"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                value={cutoffDate}
+                onChange={(e) => { setCutoffDate(e.target.value); setPurgeStatus(null); }}
+                disabled={loading}
+              />
+            </div>
+            {purgeStatus && (
+              <p className={`text-xs ${purgeStatus.type === "success" ? "text-green-700" : "text-red-600"}`}>
+                {purgeStatus.message}
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={() => { void handlePurgeBefore(); }}
+              disabled={loading || !cutoffDate.trim()}
+              className="rounded bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800 disabled:opacity-50"
+            >
+              {loading ? "Processing…" : "Purge Records"}
+            </button>
+          </div>
+        </div>
+
+        {/* Delete Learner Records */}
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-5">
+          <h2 className="font-semibold text-slate-900">Delete Learner Records (GDPR)</h2>
+          <p className="mt-1 text-xs text-slate-600">
+            Permanently deletes all ledger records for a specific learner. Used for GDPR right-to-erasure
+            requests.
+          </p>
+          <div className="mt-4 space-y-3">
+            <div>
+              <label htmlFor="learner-id" className="block text-xs font-medium text-slate-700">
+                Learner ID (Clerk user ID)
+              </label>
+              <input
+                id="learner-id"
+                type="text"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm font-mono"
+                placeholder="user_xxxxxxxxxxxxxxxx"
+                value={learnerId}
+                onChange={(e) => { setLearnerId(e.target.value); setDeleteStatus(null); }}
+                disabled={loading}
+              />
+            </div>
+            {deleteStatus && (
+              <p className={`text-xs ${deleteStatus.type === "success" ? "text-green-700" : "text-red-600"}`}>
+                {deleteStatus.message}
+              </p>
+            )}
+            <button
+              type="button"
+              onClick={() => { void handleDeleteLearner(); }}
+              disabled={loading || !learnerId.trim()}
+              className="rounded bg-red-700 px-4 py-2 text-sm font-medium text-white hover:bg-red-800 disabled:opacity-50"
+            >
+              {loading ? "Processing…" : "Delete Learner Records"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/command-center/CommandCenterDashboard.tsx
+++ b/components/command-center/CommandCenterDashboard.tsx
@@ -7,10 +7,11 @@ import { localLedgerAdapter } from "@/lib/ledger/adapter";
 type SummaryStats = {
   activeCohorts: number;
   reviewBacklog: number;
+  pickupQueue: number;
 };
 
 export default function CommandCenterDashboard() {
-  const [stats, setStats] = useState<SummaryStats>({ activeCohorts: 0, reviewBacklog: 0 });
+  const [stats, setStats] = useState<SummaryStats>({ activeCohorts: 0, reviewBacklog: 0, pickupQueue: 0 });
 
   useEffect(() => {
     const records = localLedgerAdapter.readAll();
@@ -19,13 +20,24 @@ export default function CommandCenterDashboard() {
       records.filter((r) => r.type === "mission").map((r) => r.missionId)
     );
 
-    const artifactCount = records.filter(
-      (r) => r.type === "artifact"
+    const artifactMissionIds = new Set(
+      records.filter((r) => r.type === "artifact").map((r) => r.missionId)
+    );
+    const verifiedMissionIds = new Set(
+      records.filter((r) => r.type === "verification").map((r) => r.missionId)
+    );
+
+    // Pickup queue: missions with no artifact and not yet verified
+    const pickupQueue = Array.from(uniqueMissionIds).filter(
+      (id) => !artifactMissionIds.has(id) && !verifiedMissionIds.has(id)
     ).length;
+
+    const artifactCount = records.filter((r) => r.type === "artifact").length;
 
     setStats({
       activeCohorts: uniqueMissionIds.size,
       reviewBacklog: artifactCount,
+      pickupQueue,
     });
   }, []);
 
@@ -46,8 +58,8 @@ export default function CommandCenterDashboard() {
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
           <h2 className="font-semibold text-slate-900">Pickup Queue</h2>
-          <p className="mt-1 text-3xl font-bold text-slate-800">—</p>
-          <p className="mt-1 text-slate-500 text-xs">not yet wired</p>
+          <p className="mt-1 text-3xl font-bold text-slate-800">{stats.pickupQueue}</p>
+          <p className="mt-1 text-slate-500 text-xs">missions needing facilitator pickup</p>
           <Link href="/app/pickups" className="mt-2 inline-block text-xs text-slate-500 underline">
             Go to Pickups →
           </Link>

--- a/components/dashboards/AdminHome.tsx
+++ b/components/dashboards/AdminHome.tsx
@@ -1,4 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
+import { phase1FeatureFlags } from "@/lib/config/featureFlags";
+import { DEFAULT_STANDARDS } from "@/lib/standards/verifier/localVerifier";
+import type { VerificationEvent } from "@/lib/runtime/contracts/types";
+
+type AdminStats = {
+  totalStandards: number;
+  coveredStandards: number;
+  evidenceRecords: number;
+  passRate: number;
+};
+
 export default function AdminHome() {
+  const [stats, setStats] = useState<AdminStats | null>(null);
+
+  useEffect(() => {
+    const totalStandards = DEFAULT_STANDARDS.length;
+
+    if (!phase1FeatureFlags.enableLedger) {
+      setStats({ totalStandards, coveredStandards: 0, evidenceRecords: 0, passRate: 0 });
+      return;
+    }
+
+    const records = localLedgerAdapter.readAll();
+    const verifications = records.filter((r) => r.type === "verification");
+
+    const coveredIds = new Set<string>();
+    let passCount = 0;
+
+    for (const v of verifications) {
+      const payload = v.payload as VerificationEvent;
+      for (const std of payload.standards) {
+        coveredIds.add(std);
+      }
+      if (payload.verdict === "pass") passCount++;
+    }
+
+    const passRate =
+      verifications.length > 0 ? Math.round((passCount / verifications.length) * 100) : 0;
+
+    setStats({
+      totalStandards,
+      coveredStandards: coveredIds.size,
+      evidenceRecords: verifications.length,
+      passRate,
+    });
+  }, []);
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-semibold" data-tour="page-title">Home (Admin)</h1>
@@ -8,17 +60,52 @@ export default function AdminHome() {
       <div className="grid gap-3 md:grid-cols-3">
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm" data-tour="admin-standards-card">
           <h2 className="font-semibold text-slate-900">Standards Health</h2>
-          <p className="mt-1 text-slate-600">Review standards coverage and identify missing verification areas.</p>
+          {stats === null ? (
+            <p className="mt-2 text-xs text-slate-400">Loading…</p>
+          ) : (
+            <>
+              <p className="mt-1 text-3xl font-bold text-slate-800">
+                {stats.coveredStandards}/{stats.totalStandards}
+              </p>
+              <p className="mt-1 text-xs text-slate-500">standards covered by evidence</p>
+            </>
+          )}
+          <Link href="/app/standards" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Standards →
+          </Link>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm" data-tour="admin-evidence-card">
           <h2 className="font-semibold text-slate-900">Evidence Readiness</h2>
-          <p className="mt-1 text-slate-600">Track evidence volume and consistency across learner pathways.</p>
+          {stats === null ? (
+            <p className="mt-2 text-xs text-slate-400">Loading…</p>
+          ) : (
+            <>
+              <p className="mt-1 text-3xl font-bold text-slate-800">{stats.passRate}%</p>
+              <p className="mt-1 text-xs text-slate-500">
+                pass rate across {stats.evidenceRecords} verification records
+              </p>
+            </>
+          )}
+          <Link href="/app/evidence" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Evidence →
+          </Link>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm" data-tour="admin-exports-card">
           <h2 className="font-semibold text-slate-900">Export Operations</h2>
-          <p className="mt-1 text-slate-600">Validate release and reporting readiness before stakeholder export.</p>
+          <p className="mt-1 text-xs text-slate-600">
+            Validate release and reporting readiness before stakeholder export.
+          </p>
+          <Link href="/app/exports" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Exports →
+          </Link>
         </article>
       </div>
+
+      {!phase1FeatureFlags.enableLedger && (
+        <p className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          Live evidence stats require the ledger feature. Set <code>NEXT_PUBLIC_ENABLE_LEDGER=true</code> to activate.
+        </p>
+      )}
     </section>
   );
 }

--- a/components/dashboards/TeacherHome.tsx
+++ b/components/dashboards/TeacherHome.tsx
@@ -1,4 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { localLedgerAdapter } from "@/lib/ledger/adapter";
+import { phase1FeatureFlags } from "@/lib/config/featureFlags";
+import type { VerificationEvent } from "@/lib/runtime/contracts/types";
+
+type TeacherStats = {
+  interventionCount: number;
+  activeCohortCount: number;
+  reviewBacklog: number;
+};
+
 export default function TeacherHome() {
+  const [stats, setStats] = useState<TeacherStats | null>(null);
+
+  useEffect(() => {
+    if (!phase1FeatureFlags.enableLedger) {
+      setStats({ interventionCount: 0, activeCohortCount: 0, reviewBacklog: 0 });
+      return;
+    }
+
+    const records = localLedgerAdapter.readAll();
+    const missions = records.filter((r) => r.type === "mission");
+    const artifacts = records.filter((r) => r.type === "artifact");
+    const verifications = records.filter((r) => r.type === "verification");
+
+    const uniqueMissionIds = new Set(missions.map((r) => r.missionId));
+    const artifactMissionIds = new Set(artifacts.map((r) => r.missionId));
+    const verifiedMissionIds = new Set(verifications.map((r) => r.missionId));
+
+    // Intervention queue: missions with no artifact and not yet verified
+    const interventionCount = Array.from(uniqueMissionIds).filter(
+      (id) => !artifactMissionIds.has(id) && !verifiedMissionIds.has(id)
+    ).length;
+
+    // Review backlog: verifications with partial or missing verdict
+    const reviewBacklog = verifications.filter((v) => {
+      const payload = v.payload as VerificationEvent;
+      return payload.verdict === "partial" || payload.verdict === "missing";
+    }).length;
+
+    setStats({
+      interventionCount,
+      activeCohortCount: uniqueMissionIds.size,
+      reviewBacklog,
+    });
+  }, []);
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-semibold" data-tour="page-title">Home (Teacher)</h1>
@@ -8,17 +58,53 @@ export default function TeacherHome() {
       <div className="grid gap-3 md:grid-cols-3">
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm" data-tour="teacher-intervention-card">
           <h2 className="font-semibold text-slate-900">Intervention Queue</h2>
-          <p className="mt-1 text-slate-600">Prioritize learner support from deterministic urgency signals.</p>
+          {stats === null ? (
+            <p className="mt-2 text-xs text-slate-400">Loading…</p>
+          ) : (
+            <>
+              <p className="mt-1 text-3xl font-bold text-slate-800">{stats.interventionCount}</p>
+              <p className="mt-1 text-xs text-slate-500">missions needing facilitator support</p>
+            </>
+          )}
+          <Link href="/app/pickups" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Pickups →
+          </Link>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm" data-tour="teacher-cohort-card">
           <h2 className="font-semibold text-slate-900">Cohort Flow</h2>
-          <p className="mt-1 text-slate-600">Track cohort pacing and unblock missions with targeted actions.</p>
+          {stats === null ? (
+            <p className="mt-2 text-xs text-slate-400">Loading…</p>
+          ) : (
+            <>
+              <p className="mt-1 text-3xl font-bold text-slate-800">{stats.activeCohortCount}</p>
+              <p className="mt-1 text-xs text-slate-500">active missions tracked in ledger</p>
+            </>
+          )}
+          <Link href="/app/cohorts" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Cohorts →
+          </Link>
         </article>
         <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm" data-tour="teacher-reviews-card">
           <h2 className="font-semibold text-slate-900">Evidence Reviews</h2>
-          <p className="mt-1 text-slate-600">Review submitted artifacts and verification outcomes in one loop.</p>
+          {stats === null ? (
+            <p className="mt-2 text-xs text-slate-400">Loading…</p>
+          ) : (
+            <>
+              <p className="mt-1 text-3xl font-bold text-slate-800">{stats.reviewBacklog}</p>
+              <p className="mt-1 text-xs text-slate-500">partial or missing verifications</p>
+            </>
+          )}
+          <Link href="/app/reviews" className="mt-2 inline-block text-xs text-slate-500 underline">
+            Go to Reviews →
+          </Link>
         </article>
       </div>
+
+      {!phase1FeatureFlags.enableLedger && (
+        <p className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          Live stats require the ledger feature. Set <code>NEXT_PUBLIC_ENABLE_LEDGER=true</code> to activate.
+        </p>
+      )}
     </section>
   );
 }

--- a/components/portfolio/PortfolioView.tsx
+++ b/components/portfolio/PortfolioView.tsx
@@ -1,7 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { localLedgerAdapter, type LedgerRecord } from "@/lib/ledger/adapter";
+import { isDbLedgerFlagEnabled } from "@/lib/ledger/flags";
 import { phase1FeatureFlags } from "@/lib/config/featureFlags";
+import type { RuntimeArtifact, VerificationEvent } from "@/lib/runtime/contracts/types";
+
+async function loadDbLedgerRecords(): Promise<LedgerRecord[]> {
+  const response = await fetch("/api/ledger/records", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`ledger_records_failed_${response.status}`);
+  }
+
+  const payload = (await response.json()) as { records?: LedgerRecord[] };
+  return payload.records ?? [];
+}
 
 export default function PortfolioView() {
-  const ledgerEnabled = phase1FeatureFlags.enableLedger;
+  const [records, setRecords] = useState<LedgerRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        let loaded: LedgerRecord[];
+        if (isDbLedgerFlagEnabled()) {
+          loaded = await loadDbLedgerRecords();
+        } else {
+          loaded = localLedgerAdapter.readAll();
+        }
+        if (active) {
+          setRecords(loaded);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : "portfolio_load_failed");
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const artifacts = records.filter((r) => r.type === "artifact");
+  const verifications = records.filter((r) => r.type === "verification");
+
+  const verdictCounts = verifications.reduce(
+    (acc, v) => {
+      const payload = v.payload as VerificationEvent;
+      if (payload.verdict === "pass") acc.pass++;
+      else if (payload.verdict === "partial") acc.partial++;
+      else acc.missing++;
+      return acc;
+    },
+    { pass: 0, partial: 0, missing: 0 }
+  );
 
   return (
     <section className="space-y-4">
@@ -9,26 +73,100 @@ export default function PortfolioView() {
       <p className="text-sm text-slate-700">
         Your evidence portfolio — saved artifacts, verification results, and credential progress.
       </p>
-      {!ledgerEnabled && (
+
+      {!phase1FeatureFlags.enableLedger && (
         <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800">
           Portfolio evidence requires the ledger feature. Contact your administrator.
         </div>
       )}
-      <div className="grid gap-3 md:grid-cols-3">
-        <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-          <h2 className="font-semibold text-slate-900">Submitted Artifacts</h2>
-          <p className="mt-1 text-slate-600">Artifacts saved in Studio appear here once submitted for review.</p>
-        </article>
-        <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-          <h2 className="font-semibold text-slate-900">Verification Results</h2>
-          <p className="mt-1 text-slate-600">Standards verification outcomes for each submitted artifact are recorded here.</p>
-        </article>
-        <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
-          <h2 className="font-semibold text-slate-900">Credential Progress</h2>
-          <p className="mt-1 text-slate-600">Track progress toward credentials as your portfolio of verified work grows.</p>
-        </article>
-      </div>
-      <p className="mt-4 text-sm text-slate-500">No artifacts yet. Save work in Studio to build your portfolio.</p>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Unable to load portfolio data ({error}).
+        </div>
+      )}
+
+      {loading && (
+        <p className="text-sm text-slate-500">Loading portfolio…</p>
+      )}
+
+      {!loading && (
+        <>
+          <div className="grid gap-3 md:grid-cols-3">
+            <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
+              <h2 className="font-semibold text-slate-900">Submitted Artifacts</h2>
+              <p className="mt-1 text-3xl font-bold text-slate-800">{artifacts.length}</p>
+              <p className="mt-1 text-xs text-slate-500">artifacts saved in Studio</p>
+            </article>
+            <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
+              <h2 className="font-semibold text-slate-900">Verification Results</h2>
+              <p className="mt-1 text-3xl font-bold text-slate-800">{verifications.length}</p>
+              <p className="mt-1 text-xs text-slate-500">
+                {verdictCounts.pass} pass · {verdictCounts.partial} partial · {verdictCounts.missing} missing
+              </p>
+            </article>
+            <article className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm">
+              <h2 className="font-semibold text-slate-900">Credential Progress</h2>
+              <p className="mt-1 text-3xl font-bold text-slate-800">
+                {verifications.length > 0
+                  ? `${Math.round((verdictCounts.pass / verifications.length) * 100)}%`
+                  : "—"}
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                verified pass rate across {verifications.length} checks
+              </p>
+            </article>
+          </div>
+
+          {artifacts.length === 0 && (
+            <p className="text-sm text-slate-500">No artifacts yet. Save work in Studio to build your portfolio.</p>
+          )}
+
+          {artifacts.length > 0 && (
+            <section className="space-y-3">
+              <h2 className="text-lg font-semibold text-slate-900">Artifact Gallery</h2>
+              <ol className="space-y-2" data-tour="artifact-gallery">
+                {artifacts.slice(0, 20).map((record) => {
+                  const artifact = record.payload as RuntimeArtifact;
+                  const linked = verifications.filter(
+                    (v) => (v.payload as VerificationEvent).artifactId === artifact.id
+                  );
+                  const verdict = linked.length > 0 ? (linked[0].payload as VerificationEvent).verdict : null;
+                  return (
+                    <li
+                      key={record.id}
+                      className="rounded-lg border border-slate-200 bg-white p-4 text-sm"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate font-mono text-xs text-slate-400">{artifact.id}</p>
+                          <p className="mt-1 line-clamp-2 text-slate-700">{artifact.content || "(empty artifact)"}</p>
+                        </div>
+                        {verdict && (
+                          <span
+                            className={`shrink-0 rounded px-2 py-0.5 text-xs font-medium ${
+                              verdict === "pass"
+                                ? "bg-green-100 text-green-800"
+                                : verdict === "partial"
+                                ? "bg-amber-100 text-amber-800"
+                                : "bg-red-100 text-red-800"
+                            }`}
+                          >
+                            {verdict}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-2 text-xs text-slate-400">
+                        {new Date(record.updatedAtIso).toLocaleString()} · mission: {record.missionId}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ol>
+            </section>
+          )}
+        </>
+      )}
     </section>
   );
 }

--- a/components/super-admin/AuditLogViewer.tsx
+++ b/components/super-admin/AuditLogViewer.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type AuditEntry = {
+  traceId: string;
+  eventType: string;
+  role: string;
+  orgId?: string;
+  actorId?: string;
+  severity: "info" | "warning" | "error";
+  metadata?: Record<string, unknown>;
+  createdAtIso: string;
+};
+
+const SEVERITY_BADGE: Record<string, string> = {
+  info: "bg-blue-100 text-blue-800",
+  warning: "bg-amber-100 text-amber-800",
+  error: "bg-red-100 text-red-800",
+};
+
+export default function AuditLogViewer() {
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        const response = await fetch("/api/super-admin/audit-log?limit=200", { cache: "no-store" });
+        if (!response.ok) {
+          const payload = (await response.json()) as { error?: string };
+          throw new Error(payload.error ?? `audit_log_fetch_failed_${response.status}`);
+        }
+        const payload = (await response.json()) as { entries: AuditEntry[]; total: number };
+        if (active) {
+          setEntries(payload.entries);
+          setTotal(payload.total);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : "audit_log_fetch_failed");
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const filtered = filter.trim()
+    ? entries.filter(
+        (e) =>
+          e.eventType.toLowerCase().includes(filter.toLowerCase()) ||
+          e.role.toLowerCase().includes(filter.toLowerCase()) ||
+          (e.actorId ?? "").toLowerCase().includes(filter.toLowerCase())
+      )
+    : entries;
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-2xl font-semibold" data-tour="page-title">Audit Log</h1>
+      <p className="text-sm text-slate-700" data-tour="page-description">
+        Browse platform audit events recorded by the system. File logging requires{" "}
+        <code>AUDIT_LOG_TO_FILE=true</code>.
+      </p>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Unable to load audit log ({error}).
+        </div>
+      )}
+
+      {!loading && !error && entries.length === 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
+          <p className="font-medium text-slate-800">No audit events found.</p>
+          <p className="mt-1">
+            Set <code>AUDIT_LOG_TO_FILE=true</code> (non-Vercel) to persist audit events for browsing.
+            Events are always emitted to stdout.
+          </p>
+        </div>
+      )}
+
+      {!loading && entries.length > 0 && (
+        <>
+          <div className="flex items-center gap-3">
+            <input
+              type="text"
+              className="w-full max-w-xs rounded border border-slate-300 px-3 py-1.5 text-sm"
+              placeholder="Filter by event type, role, actor…"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            <p className="text-xs text-slate-500">
+              {filtered.length} of {total} event{total !== 1 ? "s" : ""}
+            </p>
+          </div>
+
+          <ol className="space-y-2">
+            {filtered.map((entry, idx) => (
+              <li
+                key={`${entry.traceId}-${idx}`}
+                className="rounded-lg border border-slate-200 bg-white p-4 text-sm"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs font-medium ${SEVERITY_BADGE[entry.severity] ?? "bg-slate-100 text-slate-700"}`}
+                  >
+                    {entry.severity}
+                  </span>
+                  <span className="font-mono text-xs font-semibold text-slate-800">{entry.eventType}</span>
+                  <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">{entry.role}</span>
+                </div>
+                <div className="mt-2 grid grid-cols-[100px_1fr] gap-1 text-xs text-slate-500">
+                  <span className="font-medium text-slate-600">Time</span>
+                  <span>{new Date(entry.createdAtIso).toLocaleString()}</span>
+                  {entry.actorId && (
+                    <>
+                      <span className="font-medium text-slate-600">Actor</span>
+                      <span className="font-mono">{entry.actorId}</span>
+                    </>
+                  )}
+                  {entry.orgId && (
+                    <>
+                      <span className="font-medium text-slate-600">Org</span>
+                      <span className="font-mono">{entry.orgId}</span>
+                    </>
+                  )}
+                  <span className="font-medium text-slate-600">Trace</span>
+                  <span className="font-mono">{entry.traceId}</span>
+                </div>
+                {entry.metadata && Object.keys(entry.metadata).length > 0 && (
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-xs text-slate-400 hover:text-slate-600">
+                      Metadata
+                    </summary>
+                    <pre className="mt-1 overflow-x-auto rounded bg-slate-50 p-2 text-xs text-slate-600">
+                      {JSON.stringify(entry.metadata, null, 2)}
+                    </pre>
+                  </details>
+                )}
+              </li>
+            ))}
+          </ol>
+        </>
+      )}
+
+      {loading && <p className="text-sm text-slate-500">Loading audit log…</p>}
+    </section>
+  );
+}

--- a/docs/qa/role-matrix.md
+++ b/docs/qa/role-matrix.md
@@ -1,6 +1,6 @@
 # Role QA Matrix
 
-**Last Updated:** 2026-02-27
+**Last Updated:** 2026-02-28
 
 | Route | student_independent | student_enrolled | adult_learner | teacher | professional_development | admin | super_admin | Implementation Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|
@@ -9,10 +9,10 @@
 | `/app/core` | allow | allow | allow | allow | allow | allow | allow | functional | Flag-gated bridge runtime; ALL_ROLES per routeAccess.ts |
 | `/app/missions` | allow | allow | allow | deny | deny | deny | deny | placeholder | Learner mission flow; renders MissionsList component |
 | `/app/studio` | allow | allow | allow | deny | deny | deny | deny | placeholder | Artifact creation workspace; renders StudioWorkspace component |
-| `/app/portfolio` | allow | allow | allow | deny | deny | deny | deny | placeholder | Learner portfolio view |
+| `/app/portfolio` | allow | allow | allow | deny | deny | deny | deny | functional | Learner portfolio view; ledger-bound artifact gallery with verification verdicts |
 | `/app/credentials` | allow | allow | allow | deny | deny | deny | deny | wired | Renders CredentialsSummary; ledger-read wired |
 | `/app/settings` | allow | allow | allow | deny | deny | deny | deny | wired | Learner settings health; AI/MCP/flag status checks wired |
-| `/app/command-center` | deny | deny | deny | allow | allow | deny | deny | functional | Live stats from ledger (activeCohorts, reviewBacklog); fully wired |
+| `/app/command-center` | deny | deny | deny | allow | allow | deny | deny | functional | Live stats from ledger (activeCohorts, pickupQueue, reviewBacklog); fully wired |
 | `/app/cohorts` | deny | deny | deny | allow | allow | deny | deny | functional | Ledger-derived cohort list with learner counts; empty state shown until missions exist |
 | `/app/reviews` | deny | deny | deny | allow | allow | deny | deny | functional | Ledger-read ReviewQueue; Approve/Return/Flag actions wired |
 | `/app/pickups` | deny | deny | deny | allow | allow | deny | deny | wired | Feature-flag gated (NEXT_PUBLIC_ENABLE_PICKUP); ledger-read queues when enabled |
@@ -25,6 +25,8 @@
 | `/app/super-admin/teachers` | deny | deny | deny | deny | deny | deny | allow | functional | Super Admin teacher role assignment |
 | `/app/super-admin/licenses` | deny | deny | deny | deny | deny | deny | allow | functional | Super Admin license and trial management |
 | `/app/super-admin/institutions` | deny | deny | deny | deny | deny | deny | allow | functional | Super Admin institution account management |
+| `/app/retention` | deny | deny | deny | deny | deny | allow | allow | functional | Admin data lifecycle and GDPR retention management; requires DB ledger |
+| `/app/super-admin/audit-log` | deny | deny | deny | deny | deny | deny | allow | functional | Super Admin audit event browser; reads docs/status/audit-log.ndjson |
 | `/app/forbidden` | allow | allow | allow | allow | allow | allow | allow | functional | In-app 403 route |
 
 ## Implementation Status Key

--- a/docs/status/release-gate-latest.json
+++ b/docs/status/release-gate-latest.json
@@ -1,151 +1,166 @@
 {
-  "generatedAtIso": "2026-02-28T14:26:01.921Z",
+  "generatedAtIso": "2026-02-28T16:36:41.301Z",
   "checks": [
     {
       "script": "lint",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:24:47.768Z",
-      "finishedAtIso": "2026-02-28T14:24:52.478Z"
+      "status": "failed",
+      "passed": false,
+      "exitCode": 2,
+      "startedAtIso": "2026-02-28T16:36:40.073Z",
+      "finishedAtIso": "2026-02-28T16:36:41.300Z"
     },
     {
       "script": "typecheck",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:24:52.478Z",
-      "finishedAtIso": "2026-02-28T14:24:55.863Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "build",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:24:55.863Z",
-      "finishedAtIso": "2026-02-28T14:25:36.186Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:env",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:36.186Z",
-      "finishedAtIso": "2026-02-28T14:25:37.994Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:env-parity",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:37.994Z",
-      "finishedAtIso": "2026-02-28T14:25:39.801Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:engine-smoke",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:39.801Z",
-      "finishedAtIso": "2026-02-28T14:25:41.562Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:webhook-contract",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:41.562Z",
-      "finishedAtIso": "2026-02-28T14:25:43.391Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:security-checklist",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:43.391Z",
-      "finishedAtIso": "2026-02-28T14:25:45.144Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:branch-policy",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:45.144Z",
-      "finishedAtIso": "2026-02-28T14:25:46.891Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:swarm-overlap",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:46.891Z",
-      "finishedAtIso": "2026-02-28T14:25:48.699Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:role-routes",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:48.699Z",
-      "finishedAtIso": "2026-02-28T14:25:50.448Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:runtime-routes",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:50.448Z",
-      "finishedAtIso": "2026-02-28T14:25:52.197Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:onboarding",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:52.197Z",
-      "finishedAtIso": "2026-02-28T14:25:53.953Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:runtime-ledger-consistency",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:53.953Z",
-      "finishedAtIso": "2026-02-28T14:25:55.735Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:http-smoke",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:55.736Z",
-      "finishedAtIso": "2026-02-28T14:25:58.336Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:super-admin-contracts",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:25:58.336Z",
-      "finishedAtIso": "2026-02-28T14:26:00.109Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:ledger-contracts",
-      "status": "passed",
-      "passed": true,
-      "exitCode": 0,
-      "startedAtIso": "2026-02-28T14:26:00.110Z",
-      "finishedAtIso": "2026-02-28T14:26:01.921Z"
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     },
     {
       "script": "verify:cloud-aws-smoke",
-      "status": "skipped",
-      "passed": null,
+      "status": "not_run",
+      "passed": false,
       "exitCode": null,
       "startedAtIso": null,
-      "finishedAtIso": null,
-      "note": "E2E_ADMIN_EMAIL not set"
+      "finishedAtIso": null
+    },
+    {
+      "script": "verify:federation-smoke",
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
+    },
+    {
+      "script": "verify:health-check",
+      "status": "not_run",
+      "passed": false,
+      "exitCode": null,
+      "startedAtIso": null,
+      "finishedAtIso": null
     }
   ],
-  "passed": true
+  "passed": false
 }

--- a/lib/auth/routeAccess.ts
+++ b/lib/auth/routeAccess.ts
@@ -48,10 +48,12 @@ export const APP_ROUTE_DEFINITIONS: readonly AppRouteDefinition[] = [
   { path: "/app/standards", title: "Standards", description: "Admin standards placeholder.", allowedRoles: [...ADMIN_ROLE, ...SUPER_ADMIN_ROLE] },
   { path: "/app/evidence", title: "Evidence", description: "Admin evidence read view.", allowedRoles: [...ADMIN_ROLE, ...SUPER_ADMIN_ROLE] },
   { path: "/app/exports", title: "Exports", description: "Admin export tools placeholder.", allowedRoles: [...ADMIN_ROLE, ...SUPER_ADMIN_ROLE] },
+  { path: "/app/retention", title: "Data Retention", description: "Admin data lifecycle and retention management.", allowedRoles: [...ADMIN_ROLE, ...SUPER_ADMIN_ROLE] },
   { path: "/app/super-admin/users", title: "User Roster", description: "SuperAdmin user account management.", allowedRoles: SUPER_ADMIN_ROLE },
   { path: "/app/super-admin/teachers", title: "Teacher Assignment", description: "SuperAdmin teacher role assignment.", allowedRoles: SUPER_ADMIN_ROLE },
   { path: "/app/super-admin/licenses", title: "License Manager", description: "SuperAdmin license and trial management.", allowedRoles: SUPER_ADMIN_ROLE },
   { path: "/app/super-admin/institutions", title: "Institutions", description: "SuperAdmin institution account management.", allowedRoles: SUPER_ADMIN_ROLE },
+  { path: "/app/super-admin/audit-log", title: "Audit Log", description: "SuperAdmin platform audit event browser.", allowedRoles: SUPER_ADMIN_ROLE },
   { path: "/app/forbidden", title: "Access Restricted", description: "In-app 403 view.", allowedRoles: ALL_ROLES }
 ] as const;
 

--- a/lib/nav/items.ts
+++ b/lib/nav/items.ts
@@ -61,6 +61,7 @@ export const NAV_ITEMS_BY_ROLE: Readonly<Record<AppRole, readonly NavItem[]>> = 
     { href: "/app/standards", label: "Standards" },
     { href: "/app/evidence", label: "Evidence" },
     { href: "/app/exports", label: "Exports" },
+    { href: "/app/retention", label: "Retention" },
     { href: "/app/core", label: "Core" },
     { href: "/app/profile", label: "Profile" }
   ],
@@ -70,6 +71,7 @@ export const NAV_ITEMS_BY_ROLE: Readonly<Record<AppRole, readonly NavItem[]>> = 
     { href: "/app/super-admin/teachers", label: "Teacher Assignment" },
     { href: "/app/super-admin/licenses", label: "Licenses" },
     { href: "/app/super-admin/institutions", label: "Institutions" },
+    { href: "/app/super-admin/audit-log", label: "Audit Log" },
     { href: "/app/core", label: "Core" },
     { href: "/app/profile", label: "Profile" }
   ]

--- a/scripts/verify-role-routes.mjs
+++ b/scripts/verify-role-routes.mjs
@@ -22,8 +22,8 @@ const roleToExpectedNav = {
   adult_learner: ["/app/studio", "/app/credentials", "/app/settings"],
   teacher: ["/app/command-center", "/app/cohorts", "/app/reviews", "/app/pickups", "/app/builder"],
   professional_development: ["/app/command-center", "/app/cohorts", "/app/reviews", "/app/pickups", "/app/builder"],
-  admin: ["/app/evidence", "/app/exports", "/app/standards"],
-  super_admin: ["/app/super-admin/users", "/app/super-admin/teachers", "/app/super-admin/licenses", "/app/super-admin/institutions"]
+  admin: ["/app/evidence", "/app/exports", "/app/standards", "/app/retention"],
+  super_admin: ["/app/super-admin/users", "/app/super-admin/teachers", "/app/super-admin/licenses", "/app/super-admin/institutions", "/app/super-admin/audit-log"]
 };
 
 const roleToForbiddenNav = {


### PR DESCRIPTION
## Summary
Adds data retention management and audit log viewing capabilities for administrators and super admins. Includes new UI components for purging records by date and deleting learner data (GDPR), plus an audit log viewer for super admins. Updates portfolio view to display ledger records with verification verdicts.

## Scope
### In Scope
- New `DataRetentionManager` component for purging records and deleting learner data
- New `AuditLogViewer` component for browsing platform audit events
- Enhanced `PortfolioView` to load and display ledger records with artifact gallery
- Updated admin and teacher home dashboards with real statistics from ledger
- New routes: `/app/retention` (admin) and `/app/super-admin/audit-log` (super_admin)
- API endpoint: `GET /api/super-admin/audit-log` for fetching audit entries
- Updated role matrix and navigation items to include new routes

### Out of Scope
- Audit log file writing implementation (assumes `AUDIT_LOG_TO_FILE` env var)
- Data retention API endpoints (assumes `/api/admin/retention` exists)
- Ledger record persistence (uses existing adapter)

## Dependencies
- None

## Acceptance Criteria
1. Admin users can access `/app/retention` to purge records by date or delete learner data
2. Super admins can access `/app/super-admin/audit-log` to view platform audit events
3. Portfolio view displays artifact gallery with verification verdicts when ledger is enabled
4. Admin and teacher dashboards show real statistics from ledger records
5. All new routes respect role-based access control
6. Navigation items updated for admin and super_admin roles

## Test Routes
- [ ] `/app/retention` (admin only)
- [ ] `/app/super-admin/audit-log` (super_admin only)
- [ ] `/app/portfolio` (all authenticated users)
- [ ] `/app` (admin dashboard with stats)
- [ ] `/app/command-center` (teacher dashboard with stats)

## Verification
- [ ] `npm run lint` (currently failing - lint check needs to pass)
- [ ] `npm run typecheck`
- [ ] `npm run build`
- [ ] `npm run verify:role-routes`
- [ ] `npm run verify:runtime-routes`

## Manual Role Evidence
- [ ] Admin can access `/app/retention` and `/app/evidence`
- [ ] Super admin can access `/app/super-admin/audit-log`
- [ ] Student/teacher cannot access admin-only routes (403 shown)

## UI Evidence
- [ ] Data retention manager shows two-column layout with purge and delete sections
- [ ] Audit log viewer displays entries with severity badges and metadata
- [ ] Portfolio view shows artifact gallery with verification verdict badges
- [ ] Admin/teacher dashboards display statistics cards

## Env Changes
- [ ] No new env vars required (uses existing `NEXT_PUBLIC_ENABLE_DB_LEDGER`, `AUDIT_LOG_TO_FILE`)

## Guardrails Check
- [ ] 16 files changed (within limit)
- [ ] No unrelated refactor
- [ ] Feature flags respected (`phase1FeatureFlags.enableLedger`)
- [ ] No parallel PR overlap

**Note:** Release gate currently shows lint failure (exit code 2). This PR introduces the features but lint verification needs to pass before merge.

https://claude.ai/code/session_01Eq7Wi53D8XoXEyvSMFiaJG