### PR TITLE
Eighth-pass gap analysis: fix P0/P1/P2/P3 items + file 29 issues (#202–#229)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,9 @@ AWS_DYNAMODB_LICENSING_TABLE=
 AWS_DYNAMODB_STANDARDS_TABLE=
 AWS_EVENTBRIDGE_BUS_NAME=
 BEDROCK_MODEL_ID=amazon.titan-text-express-v1
+# AWS_BEDROCK_MODEL_ID is an alias for BEDROCK_MODEL_ID used by some provider implementations.
+# Example: anthropic.claude-3-sonnet-20240229-v1:0
+# AWS_BEDROCK_MODEL_ID=
 # ALLOW_AWS_WORKER_FALLBACK: set true to fall back to in-memory queue when AWS credentials are unavailable.
 ALLOW_AWS_WORKER_FALLBACK=false
 # DB_LEDGER_ADAPTER: selects the server-side ledger backend. Options: dynamo (Vercel/prod), sqlite (local dev).
@@ -117,6 +120,9 @@ E2E_SUPER_ADMIN_EMAIL=
 E2E_SUPER_ADMIN_PASSWORD=
 
 MODEL_ROUTING_POLICY=local_first
+# Log level for structured logger (debug | info | warn | error).
+# Defaults to "info" in production and "debug" in development.
+# LOG_LEVEL=info
 AUDIT_LOG_TO_FILE=false
 AUDIT_HTTP_ENDPOINT=
 AUDIT_HTTP_BEARER_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ npm run verify:swarm-overlap    # File-overlap conflict detection for parallel P
 
 ## 6. User Roles — Complete Reference
 
-Six roles are defined in `lib/auth/roles.ts`:
+Seven roles are defined in `lib/auth/roles.ts`:
 
 ```typescript
 export const APP_ROLES = [
@@ -154,6 +154,7 @@ export const APP_ROLES = [
   "teacher",
   "professional_development",
   "admin",
+  "super_admin",
 ] as const;
 ```
 
@@ -164,7 +165,8 @@ Role groupings (used in route access contracts):
 | `LEARNER_ROLES` | student_independent, student_enrolled, adult_learner |
 | `FACILITATOR_ROLES` | teacher, professional_development |
 | `ADMIN_ROLE` | admin |
-| `ALL_ROLES` | all six |
+| `SUPER_ADMIN_ROLE` | super_admin |
+| `ALL_ROLES` | all seven |
 
 ### Role Requirements
 
@@ -185,11 +187,10 @@ Role groupings (used in route access contracts):
 | student_independent | `PLEHome` | ✅ Implemented |
 | student_enrolled | `PLEHome` | ✅ Implemented |
 | adult_learner | `AdultLearnerHome` | ✅ Implemented |
-| teacher | `PLEHome` | ⚠️ **GAP** — falls through to student UI |
+| teacher | `TeacherHome` | ✅ Implemented |
 | professional_development | `ProfessionalDevelopmentHome` | ✅ Implemented |
-| admin | `PLEHome` | ⚠️ **GAP** — falls through to student UI |
-
-> **Critical gap**: `teacher` and `admin` currently render `PLEHome` because `app/app/page.tsx` has no branch for these roles. Both need dedicated home dashboards.
+| admin | `AdminHome` | ✅ Implemented |
+| super_admin | `SuperAdminHome` | ✅ Implemented |
 
 ---
 
@@ -410,9 +411,40 @@ All of the following have been implemented and closed:
 
 | GAP-15 | Landing page CTA differentiation | ✅ `?intent=teacher` / `?intent=admin` params + contextual banner in sign-in page |
 
-### No remaining gaps
+### Eighth Pass — New Gaps Identified (2026-03-08)
 
-All known gaps are resolved as of the sixth pass (2026-02-27).
+**29 new gaps** found in a deep file-by-file analysis. GitHub issues #202–#229. Not all resolvable in a single PR.
+
+| Issue | Gap | Priority | Status |
+|-------|-----|----------|--------|
+| #202 | `super_admin` excluded from ledger API GET/POST | P0 | ✅ Fixed in this PR |
+| #203 | Timeline route loads ALL records before filtering (OOM) | P0 | ✅ Fixed in this PR |
+| #204 | In-memory rate limiter resets on Vercel cold start | P0 | Open |
+| #205 | Local `ORG_REQUIRED_ROLES` dupe in assign-role route | P1 | Open |
+| #206 | `user!.id` non-null assertion after role-only check | P1 | ✅ Fixed in this PR |
+| #207 | Silent JSON swallow in orchestration worker-run | P1 | ✅ Fixed in this PR |
+| #208 | No try-catch on DynamoDB calls in runtime/state route | P1 | Open |
+| #209 | Audit log API reads file only with no source indicator | P1 | Open |
+| #210 | `/api/ai/health` is completely unauthenticated | P1 | ✅ Fixed in this PR |
+| #211 | Facilitator can write ledger records for any learnerId | P1 | Open |
+| #212 | Missing rate limits on retention/profile/users/runtime | P1 | Open |
+| #213 | release-gate non-blocking checks never run | P2 | Open |
+| #214 | In-memory ledger silently swallows parse failures | P2 | ✅ Fixed in this PR |
+| #215 | No localStorage quota guard in ledger adapter | P2 | ✅ Fixed in this PR |
+| #216 | DynamoDB adapter calls have no try-catch | P2 | Open |
+| #217 | `LOG_LEVEL` undocumented in `.env.example` | P2 | ✅ Fixed in this PR |
+| #218 | `AWS_BEDROCK_MODEL_ID` alias undocumented | P2 | ✅ Fixed in this PR |
+| #219 | Clerk user list hard-coded limit=100, no pagination | P2 | Open |
+| #220 | Onboarding verifier lacks role-specific step count checks | P2 | Open |
+| #221 | `student_enrolled` tour missing workflow steps | P2 | ✅ Fixed in this PR |
+| #222 | Audit log file path cwd-relative, fails on serverless | P2 | Open |
+| #223 | Verify scripts use brittle string matching | P2 | Open |
+| #224 | `LedgerAdapter` interface missing `findByLearner()` | P3 | ✅ Fixed in this PR |
+| #225 | CLAUDE.md listed "Six roles" (should be seven) | P3 | ✅ Fixed in this PR |
+| #226 | `GITHUB_ISSUES_SEVENTH_PASS.md` showed all issues as Open | P3 | ✅ Fixed in this PR |
+| #227 | `production-readiness-gap-analysis.md` stale (45%) | P3 | ✅ Archived in this PR |
+| #228 | `/api/mcp/health` and `/api/offline/status` unauthenticated | P3 | Open |
+| #229 | `featureFlags.ts` missing module-load-time comment | P3 | ✅ Fixed in this PR |
 
 ---
 

--- a/app/api/ai/health/route.ts
+++ b/app/api/ai/health/route.ts
@@ -1,5 +1,7 @@
+import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
+import { parseAppRole } from "@/lib/auth/userRole";
 import { CloudManagedProvider } from "@/lib/llm/providers/cloudManaged";
 import { LocalOllamaProvider } from "@/lib/llm/providers/localOllama";
 import { getFederationDiscovery } from "@/lib/federation/registry";
@@ -9,6 +11,15 @@ export const runtime = "nodejs";
 
 export async function GET(request: Request): Promise<Response> {
   const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return NextResponse.json(
+      { error: "Authenticated session required." },
+      { status: 401, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
   const local = new LocalOllamaProvider();
   const cloud = new CloudManagedProvider();
 

--- a/app/api/inference/route.ts
+++ b/app/api/inference/route.ts
@@ -57,14 +57,14 @@ export async function POST(request: Request): Promise<Response> {
   const user = await currentUser();
   const role = parseAppRole(user?.publicMetadata?.role);
 
-  if (!role) {
+  if (!role || !user?.id) {
     return NextResponse.json(
       { error: "Authorized role required." },
       { status: 403, headers: { [TRACE_HEADER]: traceId } }
     );
   }
 
-  const rateLimitResponse = enforceRateLimit(user!.id, "/api/inference", RATE_LIMITS.inference, traceId);
+  const rateLimitResponse = enforceRateLimit(user.id, "/api/inference", RATE_LIMITS.inference, traceId);
   if (rateLimitResponse) return rateLimitResponse;
 
   let body: InferenceBody;

--- a/app/api/ledger/records/route.ts
+++ b/app/api/ledger/records/route.ts
@@ -83,7 +83,7 @@ export async function GET(request: Request): Promise<Response> {
       return withTrace(400, traceId, { error: "learnerId is required for facilitator ledger reads." });
     }
     effectiveLearnerId = requestedLearnerId;
-  } else if (role === "admin") {
+  } else if (role === "admin" || role === "super_admin") {
     effectiveLearnerId = requestedLearnerId ?? null;
   } else {
     return withTrace(403, traceId, { error: "Authorized role required." });
@@ -130,7 +130,7 @@ export async function POST(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Learners can only write their own records." });
   }
 
-  const allowedWriter = isLearnerRole(role) || isFacilitatorRole(role) || role === "admin";
+  const allowedWriter = isLearnerRole(role) || isFacilitatorRole(role) || role === "admin" || role === "super_admin";
   if (!allowedWriter) {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }

--- a/app/api/orchestration/worker-run/route.ts
+++ b/app/api/orchestration/worker-run/route.ts
@@ -143,17 +143,25 @@ export async function POST(request: Request): Promise<Response> {
   const user = await currentUser();
   const role = parseAppRole(user?.publicMetadata?.role);
 
-  if (!role || (role !== "admin" && role !== "super_admin" && role !== "teacher" && role !== "professional_development")) {
+  if (!role || !user?.id || (role !== "admin" && role !== "super_admin" && role !== "teacher" && role !== "professional_development")) {
     return NextResponse.json(
       { error: "Facilitator/admin role required." },
       { status: 403, headers: { [TRACE_HEADER]: traceId } }
     );
   }
 
-  const rateLimitResponse = enforceRateLimit(user!.id, "/api/orchestration/worker-run", RATE_LIMITS.mutation, traceId);
+  const rateLimitResponse = enforceRateLimit(user.id, "/api/orchestration/worker-run", RATE_LIMITS.mutation, traceId);
   if (rateLimitResponse) return rateLimitResponse;
 
-  const body = (await request.json().catch(() => ({}))) as WorkerRunBody;
+  let body: WorkerRunBody;
+  try {
+    body = (await request.json()) as WorkerRunBody;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
   const enqueuedJob = buildJob(body, traceId);
 
   const preferredStore = canUseDynamo()

--- a/app/api/timeline/learner/route.ts
+++ b/app/api/timeline/learner/route.ts
@@ -23,11 +23,18 @@ export async function GET(request: Request): Promise<Response> {
     );
   }
 
+  if (!user?.id) {
+    return NextResponse.json(
+      { error: "Authenticated session required." },
+      { status: 401, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
+
   let records;
   try {
     records = isDbLedgerAvailable()
-      ? createDbLedgerAdapter().readAll()
-      : localLedgerAdapter.readAll();
+      ? createDbLedgerAdapter().findByLearner(user.id)
+      : localLedgerAdapter.findByLearner(user.id);
   } catch (error) {
     console.error("[timeline/learner] ledger_init_failed", error instanceof Error ? error.message : "unknown");
     return NextResponse.json(
@@ -36,7 +43,7 @@ export async function GET(request: Request): Promise<Response> {
     );
   }
 
-  const timeline = buildLearnerTimeline(records, user?.id);
+  const timeline = buildLearnerTimeline(records, user.id);
 
   return NextResponse.json(
     {

--- a/docs/production-readiness-gap-analysis.md
+++ b/docs/production-readiness-gap-analysis.md
@@ -1,9 +1,17 @@
 # Production Readiness Gap Analysis
 
+> **ARCHIVED — 2026-03-08**
+> This document was written on 2026-02-25 and reflected approximately 45% production readiness.
+> All gaps described below were resolved in the seventh pass (2026-02-27).
+> For current status see `docs/status/PROGRAM_STATUS.md`.
+> For the eighth-pass gap findings (2026-03-08) see GitHub issues #202–#229.
+
+---
+
 Date: 2026-02-25
 Owner: Release Captain
-Status: Active remediation
-Estimated readiness: ~45%
+Status: **ARCHIVED** (was: Active remediation)
+Estimated readiness at time of writing: ~45% → **Current estimate: ~85%** (post eighth-pass P0/P1 gaps remain)
 
 ## Critical Production Risks (P1)
 1. DB ledger path on Vercel serverless

--- a/docs/status/GITHUB_ISSUES_SEVENTH_PASS.md
+++ b/docs/status/GITHUB_ISSUES_SEVENTH_PASS.md
@@ -174,39 +174,48 @@
 
 ## Status Summary
 
+> **All issues resolved as of 2026-02-27 seventh-pass PRs.**
+
 | Issue | Gap | Priority | Status |
 |-------|-----|----------|--------|
-| #130 | GAP-30 Federation auth | Critical | Open |
-| #131 | GAP-31 shouldUseDbLedger dupe | Critical | Open |
-| #132 | GAP-32 Purge semantics | Critical | Open |
-| #133 | GAP-40 isLedgerRecord payload | High | Open |
-| #134 | GAP-41 toRecord() any cast | High | Open |
-| #135 | GAP-42 upsert atomicity | High | Open |
-| #136 | GAP-35 timeline try-catch | High | Open |
-| #137 | GAP-36 users fetch try-catch | High | Open |
-| #138 | GAP-37 assign-role fetch try-catch | High | Open |
-| #139 | GAP-38 webhook fetch try-catch | High | Open |
-| #140 | GAP-39 ledger null dereference | High | Open |
-| #141 | GAP-44 timing attack | High | Open |
-| #142 | GAP-49 telemetry runtime | Medium | Open |
-| #143 | GAP-33 layout org list | Critical | Open |
-| #144 | GAP-34 page exhaustiveness | Critical | Open |
-| #145 | GAP-45 middleware cast | High | Open |
-| #146 | GAP-46 ALL_ROLES derived | High | Open |
-| #147 | GAP-58 export role groupings | Medium | Open |
-| #148 | GAP-59 layout audit log | Medium | Open |
-| #149 | GAP-43 audit fire-and-forget | High | Open |
-| #150 | GAP-54 audit log path | Medium | Open |
-| #151 | GAP-55 trace header casing | Medium | Open |
-| #152 | GAP-61 LLM router null | Medium | Open |
-| #153 | GAP-68 trace ID UUID | Low | Open |
-| #154 | GAP-47 smoke test | High | Open |
-| #155 | GAP-56 role-routes brittle | Medium | Open |
-| #156 | GAP-57 onboarding regex | Medium | Open |
-| #157 | GAP-50 diagnostics auth | Medium | Open |
-| #158 | GAP-51 health runtime | Medium | Open |
-| #159 | GAP-52 mcp/offline runtime | Medium | Open |
-| #160 | GAP-53 store.ts silent discard | Medium | Open |
-| #161 | GAP-60 super_admin nav | Medium | Open |
-| #162 | GAP-63–72 P3 polish | Low | Open |
-EOF
+| #130 | GAP-30 Federation auth | Critical | ✅ Resolved |
+| #131 | GAP-31 shouldUseDbLedger dupe | Critical | ✅ Resolved |
+| #132 | GAP-32 Purge semantics | Critical | ✅ Resolved |
+| #133 | GAP-40 isLedgerRecord payload | High | ✅ Resolved |
+| #134 | GAP-41 toRecord() any cast | High | ✅ Resolved |
+| #135 | GAP-42 upsert atomicity | High | ✅ Resolved |
+| #136 | GAP-35 timeline try-catch | High | ✅ Resolved |
+| #137 | GAP-36 users fetch try-catch | High | ✅ Resolved |
+| #138 | GAP-37 assign-role fetch try-catch | High | ✅ Resolved |
+| #139 | GAP-38 webhook fetch try-catch | High | ✅ Resolved |
+| #140 | GAP-39 ledger null dereference | High | ✅ Resolved |
+| #141 | GAP-44 timing attack | High | ✅ Resolved |
+| #142 | GAP-49 telemetry runtime | Medium | ✅ Resolved |
+| #143 | GAP-33 layout org list | Critical | ✅ Resolved |
+| #144 | GAP-34 page exhaustiveness | Critical | ✅ Resolved |
+| #145 | GAP-45 middleware cast | High | ✅ Resolved |
+| #146 | GAP-46 ALL_ROLES derived | High | ✅ Resolved |
+| #147 | GAP-58 export role groupings | Medium | ✅ Resolved |
+| #148 | GAP-59 layout audit log | Medium | ✅ Resolved |
+| #149 | GAP-43 audit fire-and-forget | High | ✅ Resolved |
+| #150 | GAP-54 audit log path | Medium | ✅ Resolved |
+| #151 | GAP-55 trace header casing | Medium | ✅ Resolved |
+| #152 | GAP-61 LLM router null | Medium | ✅ Resolved |
+| #153 | GAP-68 trace ID UUID | Low | ✅ Resolved |
+| #154 | GAP-47 smoke test | High | ✅ Resolved |
+| #155 | GAP-56 role-routes brittle | Medium | ✅ Resolved |
+| #156 | GAP-57 onboarding regex | Medium | ✅ Resolved |
+| #157 | GAP-50 diagnostics auth | Medium | ✅ Resolved |
+| #158 | GAP-51 health runtime | Medium | ✅ Resolved |
+| #159 | GAP-52 mcp/offline runtime | Medium | ✅ Resolved |
+| #160 | GAP-53 store.ts silent discard | Medium | ✅ Resolved |
+| #161 | GAP-60 super_admin nav | Medium | ✅ Resolved |
+| #162 | GAP-63–72 P3 polish | Low | ✅ Resolved |
+
+## Eighth Pass — New Gaps Identified (2026-03-08)
+
+See issues #202–#229. A new gap analysis pass identified 29 additional items across P0–P3:
+- **P0** (#202–#204): super_admin ledger exclusion, timeline readAll memory load, in-memory rate limiter Vercel ineffectiveness
+- **P1** (#205–#212): local ORG_REQUIRED_ROLES dupe, user!.id assertions, silent JSON swallow, DynamoDB try-catch, audit log source, ai/health unauthenticated, facilitator write scope, missing rate limits
+- **P2** (#213–#223): release gate non-blocking gap, ledger parse silence, localStorage quota, DynamoDB adapter errors, .env docs, Clerk pagination, onboarding verifier, student_enrolled tour, audit path, verify brittleness
+- **P3** (#224–#229): LedgerAdapter interface, CLAUDE.md docs, stale status docs, production-readiness archive, mcp/offline auth, featureFlags comment

--- a/docs/status/PROGRAM_STATUS.md
+++ b/docs/status/PROGRAM_STATUS.md
@@ -1,6 +1,6 @@
 # RWFW LOS Program Status
 
-Last Updated: 2026-02-27 (Sixth pass)
+Last Updated: 2026-03-08 (Eighth pass gap analysis)
 Owner: Release Captain (Codex)
 
 ## Executive Status
@@ -57,7 +57,19 @@ Owner: Release Captain (Codex)
 
 ## Remaining Open Gaps
 
-**None.** All known gaps are closed as of the sixth pass (2026-02-27).
+**29 new gaps** identified in eighth pass (2026-03-08). Issues #202–#229 filed on GitHub.
+
+| Priority | Count | Issues |
+|----------|-------|--------|
+| P0 — Critical | 3 | #202, #203, #204 |
+| P1 — High | 8 | #205–#212 |
+| P2 — Medium | 11 | #213–#223 |
+| P3 — Low/Docs | 6 | #224–#229 |
+
+Key P0 items requiring immediate resolution:
+- **#202** `super_admin` excluded from ledger API GET/POST
+- **#203** Timeline route loads ALL DB records into memory before filtering (OOM risk)
+- **#204** In-memory rate limiter resets on Vercel cold start / not shared across instances
 
 ## Program Epics
 - `#104` Phase 4 Runtime Realization — **COMPLETE**

--- a/lib/config/featureFlags.ts
+++ b/lib/config/featureFlags.ts
@@ -1,3 +1,8 @@
+/**
+ * Feature flags are read from process.env at module load time (Next.js build/startup).
+ * Changing a flag value requires a redeploy — flags are NOT re-evaluated per request.
+ * All flags default to false when unset; the app must degrade gracefully when any flag is false.
+ */
 export const PHASE1_FEATURE_FLAG_KEYS = [
   "NEXT_PUBLIC_ENABLE_LEDGER",
   "NEXT_PUBLIC_ENABLE_MCP",

--- a/lib/ledger/adapter.ts
+++ b/lib/ledger/adapter.ts
@@ -16,6 +16,7 @@ export type LedgerAdapter = {
   readAll: () => LedgerRecord[];
   upsert: (record: LedgerRecord) => LedgerRecord;
   findByMission: (missionId: string) => LedgerRecord[];
+  findByLearner: (learnerId: string) => LedgerRecord[];
 };
 
 const LEDGER_STORAGE_KEY = "rootwork.ledger.records";
@@ -38,6 +39,7 @@ function readRecords(): LedgerRecord[] {
   try {
     return JSON.parse(raw) as LedgerRecord[];
   } catch {
+    console.warn("[ledger/adapter] readRecords: failed to parse stored ledger — returning empty. Data may be corrupted.");
     return [];
   }
 }
@@ -48,7 +50,11 @@ function writeRecords(records: LedgerRecord[]): LedgerRecord[] {
     return records;
   }
 
-  window.localStorage.setItem(LEDGER_STORAGE_KEY, JSON.stringify(records));
+  try {
+    window.localStorage.setItem(LEDGER_STORAGE_KEY, JSON.stringify(records));
+  } catch {
+    console.warn("[ledger/adapter] writeRecords: localStorage quota exceeded — ledger write skipped.");
+  }
   return records;
 }
 
@@ -79,5 +85,8 @@ export const localLedgerAdapter: LedgerAdapter = {
   },
   findByMission(missionId) {
     return readRecords().filter((record) => record.missionId === missionId);
+  },
+  findByLearner(learnerId) {
+    return readRecords().filter((record) => record.learnerId === learnerId);
   }
 };

--- a/lib/ledger/dbAdapter.ts
+++ b/lib/ledger/dbAdapter.ts
@@ -121,6 +121,13 @@ export function createDbLedgerAdapter(databasePath?: string): LedgerAdapter {
     ORDER BY updated_at_iso DESC
   `);
 
+  const findByLearnerStatement = database.prepare(`
+    SELECT id, type, mission_id, learner_id, payload_json, created_at_iso, updated_at_iso
+    FROM ledger_records
+    WHERE learner_id = ?
+    ORDER BY updated_at_iso DESC
+  `);
+
   const upsertStatement = database.prepare(`
     INSERT INTO ledger_records (id, type, mission_id, learner_id, payload_json, created_at_iso, updated_at_iso)
     VALUES (@id, @type, @missionId, @learnerId, @payloadJson, @createdAtIso, @updatedAtIso)
@@ -159,6 +166,18 @@ export function createDbLedgerAdapter(databasePath?: string): LedgerAdapter {
     },
     findByMission(missionId) {
       const rows = findByMissionStatement.all(missionId) as Array<{
+        id: string;
+        type: LedgerRecord["type"];
+        mission_id: string;
+        learner_id: string;
+        payload_json: string;
+        created_at_iso: string;
+        updated_at_iso: string;
+      }>;
+      return rows.map(toRecord);
+    },
+    findByLearner(learnerId) {
+      const rows = findByLearnerStatement.all(learnerId) as Array<{
         id: string;
         type: LedgerRecord["type"];
         mission_id: string;

--- a/lib/onboarding/tourSteps.ts
+++ b/lib/onboarding/tourSteps.ts
@@ -24,6 +24,11 @@ export const ROLE_TOUR_STEPS: Readonly<Record<AppRole, readonly TourStep[]>> = {
   student_enrolled: [
     { id: "nav", selector: "[data-tour='primary-nav']", title: "Navigation", body: "Use the left menu to access assigned learning work." },
     { id: "home", selector: "[data-tour='page-title']", title: "Home", body: "Your enrolled learner workspace starts here." },
+    { id: "mission", selector: "[data-tour='mission-draft']", title: "Mission Draft", body: "Capture your mission objective before moving into Studio.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "mission-actions", selector: "[data-tour='mission-actions']", title: "Mission Actions", body: "Start or submit mission lifecycle events from PLE.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "studio", selector: "[data-tour='studio-entry']", title: "Studio Path", body: "Move to Studio to transform your mission draft into an artifact.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "artifact-save", selector: "[data-tour='artifact-save']", title: "Artifact Save", body: "Save artifact content to the local evidence ledger.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "verification", selector: "[data-tour='verification-summary']", title: "Verification", body: "Review standards verification summary after saving.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
     { id: "help", selector: "[data-tour='help-menu']", title: "Help Menu", body: "Restart tour from Help if needed." },
     { id: "core", selector: "[data-tour='core-mount']", title: "Core Mount", body: "Legacy core screens are available during migration.", requiredFlag: "NEXT_PUBLIC_ENABLE_CORE_VITE_MOUNT" }
   ],


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Deep eighth-pass gap analysis (2026-03-08) identified 29 new issues not caught by previous passes. This PR implements the highest-impact fixes and files tracking issues for everything else.

**GitHub issues filed:** #202–#229 (P0×3, P1×8, P2×11, P3×6)

---

## Code Fixes

### P0 — Critical
- **#202 GAP-A1** — `super_admin` now allowed in ledger API `GET` (reads all records) and `POST` (writes on behalf of learners)
- **#203 GAP-A2 + #224 GAP-D1** — Added `findByLearner(learnerId)` to `LedgerAdapter` interface, `localLedgerAdapter`, and SQLite `dbAdapter`. Timeline route now calls `findByLearner(user.id)` directly instead of `readAll()` + in-memory filter — eliminates OOM/timeout risk at scale

### P1 — High
- **#206 GAP-B2** — Replaced `user!.id` non-null assertions with `!user?.id` guards in `/api/inference` and `/api/orchestration/worker-run`
- **#207 GAP-B3** — `/api/orchestration/worker-run` now returns `400` on JSON parse failure instead of silently continuing with an empty payload
- **#210 GAP-B6** — `/api/ai/health` now requires an authenticated Clerk session (was fully unauthenticated, exposed infrastructure topology)

### P2 — Medium
- **#214 GAP-C2** — In-memory ledger `readRecords()` now logs a `console.warn` when localStorage JSON parse fails (silent data loss was invisible)
- **#215 GAP-C3** — `writeRecords()` now wraps `localStorage.setItem` in try-catch to handle `QuotaExceededError` gracefully
- **#217 GAP-C5** — `LOG_LEVEL` env var documented in `.env.example`
- **#218 GAP-C6** — `AWS_BEDROCK_MODEL_ID` alias documented in `.env.example`
- **#221 GAP-C9** — `student_enrolled` tour now includes the same workflow steps as `student_independent`: `mission-draft`, `mission-actions`, `studio-entry`, `artifact-save`, `verification-summary` (all flag-gated on `NEXT_PUBLIC_ENABLE_RUNTIME`)

### P3 — Low
- **#229 GAP-D6** — Added module-load-time JSDoc comment to `featureFlags.ts`

---

## Documentation Updates

- **CLAUDE.md** — Fixed "Six roles" → "Seven roles"; added `super_admin` to `APP_ROLES` listing; removed stale `⚠️ GAP` entries from dashboard mapping table; added eighth-pass gap tracking table (29 items)
- **`docs/status/GITHUB_ISSUES_SEVENTH_PASS.md`** — All 33 seventh-pass issues marked ✅ Resolved; eighth-pass summary appended
- **`docs/status/PROGRAM_STATUS.md`** — Updated last-modified date; documented 29 new open gaps with priority breakdown
- **`docs/production-readiness-gap-analysis.md`** — Archived with superseded notice (was showing 45% readiness from 2026-02-25)

---

## Remaining Open Gaps (not in this PR)

| Priority | Issues | Key items |
|----------|--------|-----------|
| P0 | #204 | In-memory rate limiter not shared across Vercel instances |
| P1 | #205, #208, #209, #211, #212 | assign-role ORG_REQUIRED_ROLES dupe, DynamoDB try-catch, audit log source, facilitator write scope, missing rate limits |
| P2 | #213, #216, #219, #220, #222, #223 | release gate non-blocking, DynamoDB adapter errors, Clerk pagination, onboarding verifier, audit path, verify brittleness |
| P3 | #228 | mcp/offline endpoints unauthenticated |

---

## Test Plan

- [ ] `npm run lint` passes (zero warnings)
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] `npm run verify:release-gate` passes
- [ ] As `super_admin`: `GET /api/ledger/records` returns 200 (was 403)
- [ ] As learner: `GET /api/timeline/learner` returns only own records
- [ ] `GET /api/ai/health` without auth returns 401
- [ ] `student_enrolled` onboarding tour shows 9 steps when runtime flag enabled
- [ ] `.env.example` includes `LOG_LEVEL` and `AWS_BEDROCK_MODEL_ID` comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)