### PR TITLE
Ninth-pass gap fixes: resolve #202–#229 (P0/P1/P2/P3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,9 @@ AWS_DYNAMODB_LICENSING_TABLE=
 AWS_DYNAMODB_STANDARDS_TABLE=
 AWS_EVENTBRIDGE_BUS_NAME=
 BEDROCK_MODEL_ID=amazon.titan-text-express-v1
+# AWS_BEDROCK_MODEL_ID is an alias for BEDROCK_MODEL_ID used by some provider implementations.
+# Example: anthropic.claude-3-sonnet-20240229-v1:0
+# AWS_BEDROCK_MODEL_ID=
 # ALLOW_AWS_WORKER_FALLBACK: set true to fall back to in-memory queue when AWS credentials are unavailable.
 ALLOW_AWS_WORKER_FALLBACK=false
 # DB_LEDGER_ADAPTER: selects the server-side ledger backend. Options: dynamo (Vercel/prod), sqlite (local dev).
@@ -117,6 +120,9 @@ E2E_SUPER_ADMIN_EMAIL=
 E2E_SUPER_ADMIN_PASSWORD=
 
 MODEL_ROUTING_POLICY=local_first
+# Log level for structured logger (debug | info | warn | error).
+# Defaults to "info" in production and "debug" in development.
+# LOG_LEVEL=info
 AUDIT_LOG_TO_FILE=false
 AUDIT_HTTP_ENDPOINT=
 AUDIT_HTTP_BEARER_TOKEN=

--- a/app/api/ai/health/route.ts
+++ b/app/api/ai/health/route.ts
@@ -1,5 +1,7 @@
+import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
+import { parseAppRole } from "@/lib/auth/userRole";
 import { CloudManagedProvider } from "@/lib/llm/providers/cloudManaged";
 import { LocalOllamaProvider } from "@/lib/llm/providers/localOllama";
 import { getFederationDiscovery } from "@/lib/federation/registry";
@@ -9,6 +11,15 @@ export const runtime = "nodejs";
 
 export async function GET(request: Request): Promise<Response> {
   const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return NextResponse.json(
+      { error: "Authenticated session required." },
+      { status: 401, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
   const local = new LocalOllamaProvider();
   const cloud = new CloudManagedProvider();
 

--- a/app/api/inference/route.ts
+++ b/app/api/inference/route.ts
@@ -61,14 +61,14 @@ export async function POST(request: Request): Promise<Response> {
   const user = await currentUser();
   const role = parseAppRole(user?.publicMetadata?.role);
 
-  if (!role) {
+  if (!role || !user?.id) {
     return NextResponse.json(
       { error: "Authorized role required." },
       { status: 403, headers: { [TRACE_HEADER]: traceId } }
     );
   }
 
-  const rateLimitResponse = enforceRateLimit(user!.id, "/api/inference", RATE_LIMITS.inference, traceId);
+  const rateLimitResponse = enforceRateLimit(user.id, "/api/inference", RATE_LIMITS.inference, traceId);
   if (rateLimitResponse) return rateLimitResponse;
 
   let body: InferenceBody;
@@ -110,7 +110,7 @@ export async function POST(request: Request): Promise<Response> {
       model: inferenceRequest.model,
       provider: result.provider,
       role,
-      userId: user!.id,
+      userId: user.id,
       privacyMode: inferenceRequest.privacyMode,
       temperature: inferenceRequest.temperature,
       maxTokens: inferenceRequest.maxTokens,

--- a/app/api/ledger/records/route.ts
+++ b/app/api/ledger/records/route.ts
@@ -83,7 +83,7 @@ export async function GET(request: Request): Promise<Response> {
       return withTrace(400, traceId, { error: "learnerId is required for facilitator ledger reads." });
     }
     effectiveLearnerId = requestedLearnerId;
-  } else if (role === "admin") {
+  } else if (role === "admin" || role === "super_admin") {
     effectiveLearnerId = requestedLearnerId ?? null;
   } else {
     return withTrace(403, traceId, { error: "Authorized role required." });
@@ -130,7 +130,7 @@ export async function POST(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Learners can only write their own records." });
   }
 
-  const allowedWriter = isLearnerRole(role) || isFacilitatorRole(role) || role === "admin";
+  const allowedWriter = isLearnerRole(role) || isFacilitatorRole(role) || role === "admin" || role === "super_admin";
   if (!allowedWriter) {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }

--- a/app/api/mcp/health/route.ts
+++ b/app/api/mcp/health/route.ts
@@ -1,12 +1,23 @@
+import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
+import { parseAppRole } from "@/lib/auth/userRole";
 import { phase1FeatureFlags } from "@/lib/config/featureFlags";
 import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
 
 export const runtime = "nodejs";
 
-export function GET(request: Request): Response {
+export async function GET(request: Request): Promise<Response> {
   const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return NextResponse.json(
+      { error: "Authenticated session required." },
+      { status: 401, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
 
   if (!phase1FeatureFlags.enableMcp) {
     return NextResponse.json(

--- a/app/api/offline/status/route.ts
+++ b/app/api/offline/status/route.ts
@@ -1,12 +1,23 @@
+import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
+import { parseAppRole } from "@/lib/auth/userRole";
 import { phase1FeatureFlags } from "@/lib/config/featureFlags";
 import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
 
 export const runtime = "nodejs";
 
-export function GET(request: Request): Response {
+export async function GET(request: Request): Promise<Response> {
   const traceId = getTraceIdFromRequest(request);
+  const user = await currentUser();
+  const role = parseAppRole(user?.publicMetadata?.role);
+
+  if (!role || !user?.id) {
+    return NextResponse.json(
+      { error: "Authenticated session required." },
+      { status: 401, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
 
   if (!phase1FeatureFlags.enableOffline) {
     return NextResponse.json(

--- a/app/api/orchestration/worker-run/route.ts
+++ b/app/api/orchestration/worker-run/route.ts
@@ -143,17 +143,25 @@ export async function POST(request: Request): Promise<Response> {
   const user = await currentUser();
   const role = parseAppRole(user?.publicMetadata?.role);
 
-  if (!role || (role !== "admin" && role !== "super_admin" && role !== "teacher" && role !== "professional_development")) {
+  if (!role || !user?.id || (role !== "admin" && role !== "super_admin" && role !== "teacher" && role !== "professional_development")) {
     return NextResponse.json(
       { error: "Facilitator/admin role required." },
       { status: 403, headers: { [TRACE_HEADER]: traceId } }
     );
   }
 
-  const rateLimitResponse = enforceRateLimit(user!.id, "/api/orchestration/worker-run", RATE_LIMITS.mutation, traceId);
+  const rateLimitResponse = enforceRateLimit(user.id, "/api/orchestration/worker-run", RATE_LIMITS.mutation, traceId);
   if (rateLimitResponse) return rateLimitResponse;
 
-  const body = (await request.json().catch(() => ({}))) as WorkerRunBody;
+  let body: WorkerRunBody;
+  try {
+    body = (await request.json()) as WorkerRunBody;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
   const enqueuedJob = buildJob(body, traceId);
 
   const preferredStore = canUseDynamo()

--- a/app/api/runtime/state/route.ts
+++ b/app/api/runtime/state/route.ts
@@ -46,7 +46,13 @@ export async function GET(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }
 
-  const state = await adapterResult.adapter.read(learnerId);
+  let state: unknown;
+  try {
+    state = await adapterResult.adapter.read(learnerId);
+  } catch (err) {
+    console.error("[runtime/state] read_failed", err instanceof Error ? err.message : "unknown");
+    return withTrace(503, traceId, { error: "State store read failed." });
+  }
   return withTrace(200, traceId, { learnerId, state });
 }
 
@@ -99,6 +105,11 @@ export async function PUT(request: Request): Promise<Response> {
     return withTrace(403, traceId, { error: "Authorized role required." });
   }
 
-  await adapterResult.adapter.write(learnerId, state as RuntimeState);
+  try {
+    await adapterResult.adapter.write(learnerId, state as RuntimeState);
+  } catch (err) {
+    console.error("[runtime/state] write_failed", err instanceof Error ? err.message : "unknown");
+    return withTrace(503, traceId, { error: "State store write failed." });
+  }
   return withTrace(200, traceId, { learnerId, saved: true });
 }

--- a/app/api/super-admin/assign-role/route.ts
+++ b/app/api/super-admin/assign-role/route.ts
@@ -1,21 +1,12 @@
 import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-import { APP_ROLES } from "@/lib/auth/roles";
+import { APP_ROLES, ORG_REQUIRED_ROLES } from "@/lib/auth/roles";
 import { parseAppRole } from "@/lib/auth/userRole";
 import { recordAuditEvent } from "@/lib/observability/audit";
 import { getTraceIdFromRequest, TRACE_HEADER } from "@/lib/observability/trace";
 
 export const runtime = "nodejs";
-
-// Roles that require an orgId to be set — mirrors the check in app/app/layout.tsx:40
-const ORG_REQUIRED_ROLES = new Set<string>([
-  "student_enrolled",
-  "teacher",
-  "professional_development",
-  "admin",
-  "super_admin",
-]);
 
 // Clerk user IDs must match this format
 const CLERK_USER_ID_RE = /^usr_[a-zA-Z0-9]+$/;
@@ -66,7 +57,8 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // Roles that require an org must have a non-null orgId supplied
-  if (ORG_REQUIRED_ROLES.has(role) && !orgId) {
+  // After the APP_ROLES.includes() check above, role is a valid AppRole string.
+  if (ORG_REQUIRED_ROLES.has(role as import("@/lib/auth/roles").AppRole) && !orgId) {
     return NextResponse.json(
       { error: `orgId is required when assigning role '${role}'.` },
       { status: 400, headers: { [TRACE_HEADER]: traceId } }

--- a/app/api/timeline/learner/route.ts
+++ b/app/api/timeline/learner/route.ts
@@ -23,11 +23,18 @@ export async function GET(request: Request): Promise<Response> {
     );
   }
 
+  if (!user?.id) {
+    return NextResponse.json(
+      { error: "Authenticated session required." },
+      { status: 401, headers: { [TRACE_HEADER]: traceId } }
+    );
+  }
+
   let records;
   try {
     records = isDbLedgerAvailable()
-      ? createDbLedgerAdapter().readAll()
-      : localLedgerAdapter.readAll();
+      ? createDbLedgerAdapter().findByLearner(user.id)
+      : localLedgerAdapter.findByLearner(user.id);
   } catch (error) {
     console.error("[timeline/learner] ledger_init_failed", error instanceof Error ? error.message : "unknown");
     return NextResponse.json(
@@ -36,7 +43,7 @@ export async function GET(request: Request): Promise<Response> {
     );
   }
 
-  const timeline = buildLearnerTimeline(records, user?.id);
+  const timeline = buildLearnerTimeline(records, user.id);
 
   return NextResponse.json(
     {

--- a/lib/config/featureFlags.ts
+++ b/lib/config/featureFlags.ts
@@ -1,3 +1,8 @@
+/**
+ * Feature flags are read from process.env at module load time (Next.js build/startup).
+ * Changing a flag value requires a redeploy — flags are NOT re-evaluated per request.
+ * All flags default to false when unset; the app must degrade gracefully when any flag is false.
+ */
 export const PHASE1_FEATURE_FLAG_KEYS = [
   "NEXT_PUBLIC_ENABLE_LEDGER",
   "NEXT_PUBLIC_ENABLE_MCP",

--- a/lib/ledger/adapter.ts
+++ b/lib/ledger/adapter.ts
@@ -16,6 +16,7 @@ export type LedgerAdapter = {
   readAll: () => LedgerRecord[];
   upsert: (record: LedgerRecord) => LedgerRecord;
   findByMission: (missionId: string) => LedgerRecord[];
+  findByLearner: (learnerId: string) => LedgerRecord[];
 };
 
 const LEDGER_STORAGE_KEY = "rootwork.ledger.records";
@@ -38,6 +39,7 @@ function readRecords(): LedgerRecord[] {
   try {
     return JSON.parse(raw) as LedgerRecord[];
   } catch {
+    console.warn("[ledger/adapter] readRecords: failed to parse stored ledger — returning empty. Data may be corrupted.");
     return [];
   }
 }
@@ -48,7 +50,11 @@ function writeRecords(records: LedgerRecord[]): LedgerRecord[] {
     return records;
   }
 
-  window.localStorage.setItem(LEDGER_STORAGE_KEY, JSON.stringify(records));
+  try {
+    window.localStorage.setItem(LEDGER_STORAGE_KEY, JSON.stringify(records));
+  } catch {
+    console.warn("[ledger/adapter] writeRecords: localStorage quota exceeded — ledger write skipped.");
+  }
   return records;
 }
 
@@ -79,5 +85,8 @@ export const localLedgerAdapter: LedgerAdapter = {
   },
   findByMission(missionId) {
     return readRecords().filter((record) => record.missionId === missionId);
+  },
+  findByLearner(learnerId) {
+    return readRecords().filter((record) => record.learnerId === learnerId);
   }
 };

--- a/lib/ledger/dbAdapter.ts
+++ b/lib/ledger/dbAdapter.ts
@@ -121,6 +121,13 @@ export function createDbLedgerAdapter(databasePath?: string): LedgerAdapter {
     ORDER BY updated_at_iso DESC
   `);
 
+  const findByLearnerStatement = database.prepare(`
+    SELECT id, type, mission_id, learner_id, payload_json, created_at_iso, updated_at_iso
+    FROM ledger_records
+    WHERE learner_id = ?
+    ORDER BY updated_at_iso DESC
+  `);
+
   const upsertStatement = database.prepare(`
     INSERT INTO ledger_records (id, type, mission_id, learner_id, payload_json, created_at_iso, updated_at_iso)
     VALUES (@id, @type, @missionId, @learnerId, @payloadJson, @createdAtIso, @updatedAtIso)
@@ -159,6 +166,18 @@ export function createDbLedgerAdapter(databasePath?: string): LedgerAdapter {
     },
     findByMission(missionId) {
       const rows = findByMissionStatement.all(missionId) as Array<{
+        id: string;
+        type: LedgerRecord["type"];
+        mission_id: string;
+        learner_id: string;
+        payload_json: string;
+        created_at_iso: string;
+        updated_at_iso: string;
+      }>;
+      return rows.map(toRecord);
+    },
+    findByLearner(learnerId) {
+      const rows = findByLearnerStatement.all(learnerId) as Array<{
         id: string;
         type: LedgerRecord["type"];
         mission_id: string;

--- a/lib/onboarding/tourSteps.ts
+++ b/lib/onboarding/tourSteps.ts
@@ -24,6 +24,11 @@ export const ROLE_TOUR_STEPS: Readonly<Record<AppRole, readonly TourStep[]>> = {
   student_enrolled: [
     { id: "nav", selector: "[data-tour='primary-nav']", title: "Navigation", body: "Use the left menu to access assigned learning work." },
     { id: "home", selector: "[data-tour='page-title']", title: "Home", body: "Your enrolled learner workspace starts here." },
+    { id: "mission", selector: "[data-tour='mission-draft']", title: "Mission Draft", body: "Capture your mission objective before moving into Studio.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "mission-actions", selector: "[data-tour='mission-actions']", title: "Mission Actions", body: "Start or submit mission lifecycle events from PLE.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "studio", selector: "[data-tour='studio-entry']", title: "Studio Path", body: "Move to Studio to transform your mission draft into an artifact.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "artifact-save", selector: "[data-tour='artifact-save']", title: "Artifact Save", body: "Save artifact content to the local evidence ledger.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
+    { id: "verification", selector: "[data-tour='verification-summary']", title: "Verification", body: "Review standards verification summary after saving.", requiredFlag: "NEXT_PUBLIC_ENABLE_RUNTIME" },
     { id: "help", selector: "[data-tour='help-menu']", title: "Help Menu", body: "Restart tour from Help if needed." },
     { id: "core", selector: "[data-tour='core-mount']", title: "Core Mount", body: "Legacy core screens are available during migration.", requiredFlag: "NEXT_PUBLIC_ENABLE_CORE_VITE_MOUNT" }
   ],

--- a/scripts/verify-release-gate.mjs
+++ b/scripts/verify-release-gate.mjs
@@ -116,43 +116,49 @@ if (gateFailedEarly) {
 // Run non-blocking checks only when the gate has not failed early.
 const nonBlockingResults = [];
 
-if (!gateFailedEarly) {
-  const cloudSmokeScript = "verify:cloud-aws-smoke";
-  if (!process.env.E2E_ADMIN_EMAIL) {
+/** Run a single non-blocking check, skipping it if the given envGuard is not set. */
+function runNonBlocking(script, envGuard) {
+  if (envGuard && !process.env[envGuard]) {
     console.log(
-      `[release-gate] Skipping non-blocking check ${cloudSmokeScript}: E2E_ADMIN_EMAIL is not set.`
+      `[release-gate] Skipping non-blocking check ${script}: ${envGuard} is not set.`
     );
-    nonBlockingResults.push({
-      script: cloudSmokeScript,
+    return {
+      script,
       status: "skipped",
       passed: null,
       exitCode: null,
       startedAtIso: null,
       finishedAtIso: null,
-      note: "E2E_ADMIN_EMAIL not set"
-    });
-  } else {
-    const startedAtIso = new Date().toISOString();
-    const run = runNpmScript(cloudSmokeScript);
-    const finishedAtIso = new Date().toISOString();
-    const passed = run.status === 0;
-
-    nonBlockingResults.push({
-      script: cloudSmokeScript,
-      status: passed ? "passed" : "failed",
-      passed,
-      exitCode: run.status ?? 1,
-      startedAtIso,
-      finishedAtIso,
-      blocking: false
-    });
-
-    if (!passed) {
-      console.warn(
-        `[release-gate] Non-blocking check ${cloudSmokeScript} failed (exit ${run.status ?? 1}). Gate is not blocked.`
-      );
-    }
+      note: `${envGuard} not set`
+    };
   }
+
+  const startedAtIso = new Date().toISOString();
+  const run = runNpmScript(script);
+  const finishedAtIso = new Date().toISOString();
+  const passed = run.status === 0;
+
+  if (!passed) {
+    console.warn(
+      `[release-gate] Non-blocking check ${script} failed (exit ${run.status ?? 1}). Gate is not blocked.`
+    );
+  }
+
+  return {
+    script,
+    status: passed ? "passed" : "failed",
+    passed,
+    exitCode: run.status ?? 1,
+    startedAtIso,
+    finishedAtIso,
+    blocking: false
+  };
+}
+
+if (!gateFailedEarly) {
+  nonBlockingResults.push(runNonBlocking("verify:cloud-aws-smoke", "E2E_ADMIN_EMAIL"));
+  nonBlockingResults.push(runNonBlocking("verify:federation-smoke", "NEXT_PUBLIC_ENABLE_FEDERATION"));
+  nonBlockingResults.push(runNonBlocking("verify:health-check", null));
 } else {
   // Gate failed before non-blocking checks could run.
   for (const script of nonBlockingChecks) {


### PR DESCRIPTION
## Summary

Re-applies all fixes from PR #230 (which was based on older main) onto the current main after the autonomous org eighth-pass merge. Resolves 15 of the 29 issues filed in #202–#229, plus fixes the release gate non-blocking check gap.

## Changes

### P0 — Critical
- **#202** `super_admin` now allowed in ledger API `GET` and `POST`
- **#203 + #224** `findByLearner(learnerId)` added to `LedgerAdapter` interface, `localLedgerAdapter`, and SQLite `dbAdapter`. Timeline route uses it directly — no more `readAll()` + in-memory filter

### P1 — High
- **#205** `assign-role` route no longer defines its own `ORG_REQUIRED_ROLES` Set — imports from `lib/auth/roles.ts`
- **#206** `user!.id` non-null assertions replaced with `user.id` after `!user?.id` guard in inference and orchestration routes (including the new audit block)
- **#207** `worker-run` returns `400` on JSON parse failure instead of silently proceeding with empty payload
- **#208** DynamoDB `adapter.read/write` in `runtime/state` route wrapped in try-catch → `503` on failure
- **#210** `/api/ai/health` now requires Clerk auth (was fully unauthenticated)

### P2 — Medium
- **#213** `verify-release-gate` now actually runs `federation-smoke` and `health-check` as non-blocking checks (were declared but never executed); added `runNonBlocking()` helper with per-check env guard
- **#214** Ledger adapter parse failure now logs `console.warn`
- **#215** `localStorage.setItem` wrapped in try-catch for `QuotaExceededError`
- **#217** `LOG_LEVEL` documented in `.env.example`
- **#218** `AWS_BEDROCK_MODEL_ID` alias documented in `.env.example`
- **#221** `student_enrolled` tour gets full workflow steps matching `student_independent` (5 runtime-gated steps added)

### P3 — Low
- **#228** `/api/mcp/health` and `/api/offline/status` now require authentication
- **#229** `featureFlags.ts` has module-load-time JSDoc comment

## Remaining Open (#202–#229)
- **#204** In-memory rate limiter on Vercel — needs Redis/Upstash (architectural)
- **#209** Audit log source indicator — UX enhancement
- **#211** Facilitator write scope validation — needs cohort membership lookup
- **#212** Rate limits on additional routes
- **#216** DynamoDB adapter try-catch in `lib/runtime/dynamoAdapter.ts`
- **#219** Clerk user list pagination
- **#220** Onboarding verifier role-specific step counts
- **#222** Audit log cwd-relative path
- **#223** Verify script brittleness

## Test Plan
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] As `super_admin`: `GET /api/ledger/records` → 200
- [ ] As learner: `GET /api/timeline/learner` returns only own records
- [ ] `GET /api/ai/health` without auth → 401
- [ ] `GET /api/mcp/health` without auth → 401
- [ ] `student_enrolled` onboarding shows 9 steps when runtime flag enabled
- [ ] `verify:release-gate` output shows `federation-smoke` and `health-check` in non-blocking results

🤖 Generated with [Claude Code](https://claude.com/claude-code)